### PR TITLE
Trivial change to add support for `\0` escaping

### DIFF
--- a/src/main/scala/scalaParser/syntax/Literals.scala
+++ b/src/main/scala/scalaParser/syntax/Literals.scala
@@ -37,7 +37,7 @@ trait Literals { self: Parser with Basic with Identifiers =>
       (Key.W("null") ~ !(Basic.Letter | Basic.Digit))
     }
 
-    def EscapedChars = rule { '\\' ~ anyOf("btnfr'\\\"") }
+    def EscapedChars = rule { '\\' ~ anyOf("0btnfr'\\\"") }
 
     // Note that symbols can take on the same values as keywords!
     def SymbolLiteral = rule { ''' ~ (Identifiers.PlainId | Identifiers.Keywords) }


### PR DESCRIPTION
This was causing a failure when running the parser on Rapture JSON
sources.
