### PR TITLE
Readme: @version appearing as literal

### DIFF
--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -41,9 +41,9 @@
 
         @p
             To your SBT configuration. To use with Scala.js, you'll need
-        @hl.scala(s"""
+        @hl.scala
             "com.lihaoyi" %%% "fastparse" % "@fastparse.Constants.version"
-        """)
+
         @p
             FastParse is only compatible with Scala 2.11.x.
 


### PR DESCRIPTION
> To begin using FastParse, add
> 
> "com.lihaoyi" %% "fastparse" % "0.1.3"
> To your SBT configuration. To use with Scala.js, you'll need
> 
> "com.lihaoyi" %%% "fastparse" % "@fastparse.Constants.version"

`fastparse.Constants.version` not being replaced by value.