### PR TITLE
add -J prefix for JVM options in .sbtopts

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,2 @@
 -J-Xss6m
--Xmx4096m
+-J-Xmx4096m


### PR DESCRIPTION
Since JVM Options like `-Xmx4096m` in `.sbtopts` requires `-J` prefix as documented below, please let me correct it.

Reference: sbt-launcher-script reference about `.sbtopts`.
https://github.com/sbt/sbt-launcher-package/blob/a80410996f368937e94161227fa9ecdad0f363e5/README.md

Actually `sbt` command without `-J` prefix on JVM Options in `.sbtopts` shows following warning and doesn't start sbt.
> [warn] The `-` command is deprecated in favor of `onFailure` and will be removed in 0.14.0