### PR TITLE
LiteralIgnoreCase - match a string ignoring character case

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/package.scala
+++ b/fastparse/shared/src/main/scala/fastparse/package.scala
@@ -13,6 +13,7 @@ package object fastparse {
   val End = parsers.Terminals.End
   val Index = parsers.Terminals.Index
   val AnyChar = parsers.Terminals.AnyChar
+  val IgnoreCase = parsers.Terminals.LiteralIgnoreCase
 
   val CharPred = Intrinsics.CharPred
   val CharIn = Intrinsics.CharIn

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Terminals.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Terminals.scala
@@ -69,6 +69,22 @@ object Terminals {
     }
     rec(0)
   }
+
+  def startsWithIgnoreCase(src: String, prefix: String, offset: Int) = {
+    val max = prefix.length
+    @tailrec def rec(i: Int): Boolean = {
+      if (i >= prefix.length) true
+      else if (i + offset >= src.length) false
+      else {
+        val c1: Char = src.charAt(i + offset)
+        val c2: Char = prefix.charAt(i)
+        if (c1 != c2 && c1.toLower != c2.toLower) false
+        else rec(i + 1)
+      }
+    }
+    rec(0)
+  }
+
   /**
    * Parses a literal `String`
    */
@@ -76,6 +92,18 @@ object Terminals {
     def parseRec(cfg: ParseCtx, index: Int) = {
 
       if (startsWith(cfg.input, s, index)) success(cfg.success, (), index + s.length, false)
+      else fail(cfg.failure, index)
+    }
+    override def toString = literalize(s).toString
+  }
+
+  /**
+   * Parses a literal `String` ignoring case
+   */
+  case class LiteralIgnoreCase(s: String) extends Parser[Unit]{
+
+    def parseRec(cfg: ParseCtx, index: Int) = {
+      if (startsWithIgnoreCase(cfg.input, s, index)) success(cfg.success, (), index + s.length, false)
       else fail(cfg.failure, index)
     }
     override def toString = literalize(s).toString

--- a/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
@@ -29,6 +29,14 @@ object ParsingTests extends TestSuite{
       checkFail("Hello", ("Hello WOrld!", 5), 5)
       check(" WO".!, ("Hello WOrld!", 5), Success.Mutable(" WO", 8))
     }
+    'literalIgnoreCase{
+      checkFail(IgnoreCase("Hello WOrld!"), ("hElLo", 0), 0)
+      check(IgnoreCase("Hello"), ("hElLo WOrld!", 0), Success.Mutable((), 5))
+      check(IgnoreCase("Hello").!, ("hElLo WOrld!", 0), Success.Mutable("hElLo", 5))
+      checkFail(IgnoreCase("Hello"), ("hElLo WOrld!", 5), 5)
+      check(IgnoreCase(" wo").!, ("Hello WOrld!", 5), Success.Mutable(" WO", 8))
+      check(IgnoreCase("`~!@3#$4%^&*()-_=+[{]}|\\,.? Hello World"), ("`~!@3#$4%^&*()-_=+[{]}|\\,.? hElLo wOrLd", 0), Success.Mutable((), 39))
+    }
     'repeat{
       check("Hello".!.rep, ("HelloHello!", 0), Success.Mutable(Seq("Hello", "Hello"), 10))
       check("Hello".!.rep, ("HelloHello!", 2), Success.Mutable(Seq(), 2))


### PR DESCRIPTION
Matches a string ignoring character case.
Example: 
```scala
import fastparse._

val parser = P(IgnoreCase("keyword ").rep)

val Result.Success(value, successIndex) = parser.parse("keyword Keyword keyWord ")

assert(value == (), successIndex == 24)
```
