### PR TITLE
Restrained utest dependency to test scope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val shared = Seq(
     )
   ),
   libraryDependencies ++= Seq(
-    "com.lihaoyi" %%% "utest" % "0.3.0"
+    "com.lihaoyi" %%% "utest" % "0.3.0" % "test"
   ),
   scalaJSStage in Global := FullOptStage,
   organization := "com.lihaoyi",


### PR DESCRIPTION
The utest dependency doesn't get pulled when out of tests, this way.