### PR TITLE
Failing test case for the behaviour of `end` in `rep(end=...)`

### DIFF
--- a/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
@@ -42,6 +42,8 @@ object ParsingTests extends TestSuite{
       check("Hello".!.rep, ("HelloHello!", 2), Success.Mutable(Seq(), 2))
       check("Hello".!.rep, ("HelloHello!", 5), Success.Mutable(Seq("Hello"), 10))
       check("Hello".!.rep(1), ("HelloHello!", 0), Success.Mutable(Seq("Hello", "Hello"), 10))
+      check(CharIn("abc").!.rep(end=P(&("XYZ"))), ("caXYZaa", 0), Success.Mutable(Seq("c","a"), 2))
+      check(CharIn("abc").!.rep(end=P(&("cba"))), ("cacbaaa", 0), Success.Mutable(Seq("c","a"), 2))
       checkFail("Hello".rep(1), ("HelloHello!", 2), 2)
       checkFail("Hello".rep(end="Bye") ~ End, ("HelloHello!", 0), 10)
     }


### PR DESCRIPTION
I was expecting both these parsers to match `"ca"` (perhaps my expectations about `end` are incorrect, if so, it would be great to add clarification):

* `CharIn("abc").rep(end=P(&("XYZ")))` matching on `"caXYZaa"`
* `CharIn("abc").rep(end=P(&("cba")))` matching on `"cacbaaa"`

...but currently FastParse fails on the second of the two checks:

```
[info]       		utest.AssertionError: assert({parser; str; parsed} == rhs)
[info]       		parser: fastparse.P[T] = CharIn("abc").rep(end = tests)
[info]       		str: String = cacbaaa
[info]       		parsed: fastparse.core.Result[T] = Failure((CharIn("abc") | tests):7 ..."", false)
[info]       		rhs: fastparse.core.Result[T] = Success(List(c, a), 2)
```

(Incidentally, I did have an unsuccessful go at implementing a corresponding fix, in `Repeater`, but fell over in `NullPointerException`s, of all things)