### PR TITLE
Moved FuncName to top-level

### DIFF
--- a/fastparse/js/src/main/scala/fastparse/CharPredicates.scala
+++ b/fastparse/js/src/main/scala/fastparse/CharPredicates.scala
@@ -2,18 +2,18 @@ package fastparse
 
 object CharPredicates{
   // Not available in Scala.js
-  lazy val isLetter = Utils.preCompute(_.isLetter)
-  lazy val isDigit = Utils.preCompute(_.isDigit)
-  lazy val isPrintableChar = Utils.preCompute{c =>
+  lazy val isLetter = MacroUtils.preCompute(_.isLetter)
+  lazy val isDigit = MacroUtils.preCompute(_.isDigit)
+  lazy val isPrintableChar = MacroUtils.preCompute{c =>
     val block = java.lang.Character.UnicodeBlock.of(c)
     !java.lang.Character.isISOControl(c) &&
     !java.lang.Character.isSurrogate(c) &&
     block != null &&
     block != java.lang.Character.UnicodeBlock.SPECIALS
   }
-  lazy val isMathSymbol = Utils.preCompute(_.getType == Character.MATH_SYMBOL)
-  lazy val isOtherSymbol = Utils.preCompute(_.getType == Character.OTHER_SYMBOL)
+  lazy val isMathSymbol = MacroUtils.preCompute(_.getType == Character.MATH_SYMBOL)
+  lazy val isOtherSymbol = MacroUtils.preCompute(_.getType == Character.OTHER_SYMBOL)
   // Diverges between JS and JVM
-  lazy val isUpper = Utils.preCompute(_.isUpper)
-  lazy val isLower = Utils.preCompute(_.isLower)
+  lazy val isUpper = MacroUtils.preCompute(_.isUpper)
+  lazy val isLower = MacroUtils.preCompute(_.isLower)
 }

--- a/fastparse/shared/src/main/scala/fastparse/package.scala
+++ b/fastparse/shared/src/main/scala/fastparse/package.scala
@@ -3,7 +3,7 @@ import fastparse.parsers.Intrinsics
 
 import scala.language.experimental.macros
 package object fastparse {
-  implicit def enclosingFunctionName: Utils.FuncName = macro Utils.FuncName.impl
+  implicit def enclosingFunctionName: FuncName = macro Utils.funcNameImpl
 
   val Result = core.Result
 
@@ -26,8 +26,8 @@ package object fastparse {
     if (s.length == 1) parsers.Terminals.CharLiteral(s(0))
     else parsers.Terminals.Literal(s)
 
-  def P[T](p: => Parser[T])(implicit name: Utils.FuncName): Parser[T] =
-    parsers.Combinators.Rule(name.name, () => p)
+  def P[T](p: => Parser[T])(implicit name: FuncName): Parser[T] =
+    parsers.Combinators.Rule(name, () => p) //todo: Should this be name or name.name?
 
   type P0 = Parser[Unit]
 

--- a/fastparse/shared/src/main/scala/fastparse/package.scala
+++ b/fastparse/shared/src/main/scala/fastparse/package.scala
@@ -3,7 +3,7 @@ import fastparse.parsers.Intrinsics
 
 import scala.language.experimental.macros
 package object fastparse {
-  implicit def enclosingFunctionName: FuncName = macro Utils.funcNameImpl
+  implicit def enclosingFunctionName: FuncName = macro MacroUtils.funcNameImpl
 
   val Result = core.Result
 

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
@@ -1,6 +1,5 @@
 package fastparse.parsers
 
-import fastparse.Utils.FuncName
 import fastparse._
 import fastparse.core.Result._
 import fastparse.core.{ParseCtx, Result}

--- a/utils/shared/src/main/scala/fastparse/MacroUtils.scala
+++ b/utils/shared/src/main/scala/fastparse/MacroUtils.scala
@@ -1,0 +1,42 @@
+package fastparse
+
+import fastparse.Utils.CharBitSet
+
+import scala.language.experimental.macros
+
+/**
+ * Created by nmrp3 on 18/06/15.
+ */
+object MacroUtils {
+
+  def funcNameImpl(c: Compat.Context): c.Expr[FuncName] = {
+    import c.universe._
+
+    val sym = Compat.enclosingName(c)
+    val simpleName = sym.name.decoded.toString.trim
+    val fullName = sym.fullName.trim
+
+    val name = q"$simpleName"
+
+    c.Expr[FuncName](q"fastparse.FuncName($name, $fullName)")
+  }
+
+  /**
+   * Takes a predicate and pre-generates a base64 encoded bit-set, that
+   * evaluates at run-time to create a [[CharBitSet]]. Useful for pre-computing
+   * Char predicates that are unfeasible at runtime, e.g. because they're too
+   * slow or because they don't work in Scala.js
+   */
+  def preCompute(pred: Char => Boolean): fastparse.Utils.CharBitSet = macro preComputeImpl
+
+  def preComputeImpl(c: Compat.Context)(pred: c.Expr[Char => Boolean]): c.Expr[CharBitSet] = {
+    import c.universe._
+    val evaled = c.eval(c.Expr[Char => Boolean](c.resetLocalAttrs(pred.tree.duplicate)))
+    val (first, last, array) = CharBitSet.compute((Char.MinValue to Char.MaxValue).filter(evaled))
+    val txt = CharBitSet.ints2Hex(array)
+    c.Expr[CharBitSet](q"""
+      new fastparse.Utils.CharBitSet(fastparse.Utils.CharBitSet.hex2Ints($txt), $first, $last)
+    """)
+  }
+
+}

--- a/utils/shared/src/main/scala/fastparse/Utils.scala
+++ b/utils/shared/src/main/scala/fastparse/Utils.scala
@@ -6,27 +6,28 @@ import scala.collection.mutable
 
 import scala.language.experimental.macros
 
+/**
+ * Type, which when summoned implicitly, provides the
+ * name of the nearest enclosing method for your perusal
+ */
+case class FuncName(name: String, fullName: String)
+object FuncName{
+  implicit def strToFuncName(s: String) = FuncName(s, s)
+
+}
 
 object Utils {
-  /**
-   * Type, which when summoned implicitly, provides the
-   * name of the nearest enclosing method for your perusal
-   */
-  case class FuncName(name: String, fullName: String)
-  object FuncName{
-    implicit def strToFuncName(s: String) = FuncName(s, s)
 
-    def impl(c: Compat.Context): c.Expr[FuncName] = {
-      import c.universe._
+  def funcNameImpl(c: Compat.Context): c.Expr[FuncName] = {
+    import c.universe._
 
-      val sym = Compat.enclosingName(c)
-      val simpleName = sym.name.decoded.toString.trim
-      val fullName = sym.fullName.trim
+    val sym = Compat.enclosingName(c)
+    val simpleName = sym.name.decoded.toString.trim
+    val fullName = sym.fullName.trim
 
-      val name = q"$simpleName"
+    val name = q"$simpleName"
 
-      c.Expr[FuncName](q"fastparse.Utils.FuncName($name, $fullName)")
-    }
+    c.Expr[FuncName](q"fastparse.FuncName($name, $fullName)")
   }
 
   /**

--- a/utils/shared/src/main/scala/fastparse/Utils.scala
+++ b/utils/shared/src/main/scala/fastparse/Utils.scala
@@ -4,7 +4,6 @@ import scala.annotation.{tailrec, switch}
 import acyclic.file
 import scala.collection.mutable
 
-import scala.language.experimental.macros
 
 /**
  * Type, which when summoned implicitly, provides the
@@ -16,37 +15,10 @@ object FuncName{
 
 }
 
+
+
 object Utils {
 
-  def funcNameImpl(c: Compat.Context): c.Expr[FuncName] = {
-    import c.universe._
-
-    val sym = Compat.enclosingName(c)
-    val simpleName = sym.name.decoded.toString.trim
-    val fullName = sym.fullName.trim
-
-    val name = q"$simpleName"
-
-    c.Expr[FuncName](q"fastparse.FuncName($name, $fullName)")
-  }
-
-  /**
-   * Takes a predicate and pre-generates a base64 encoded bit-set, that 
-   * evaluates at run-time to create a [[CharBitSet]]. Useful for pre-computing
-   * Char predicates that are unfeasible at runtime, e.g. because they're too
-   * slow or because they don't work in Scala.js
-   */
-  def preCompute(pred: Char => Boolean): fastparse.Utils.CharBitSet = macro preComputeImpl
-
-  def preComputeImpl(c: Compat.Context)(pred: c.Expr[Char => Boolean]): c.Expr[CharBitSet] = {
-    import c.universe._
-    val evaled = c.eval(c.Expr[Char => Boolean](c.resetLocalAttrs(pred.tree.duplicate)))
-    val (first, last, array) = CharBitSet.compute((Char.MinValue to Char.MaxValue).filter(evaled))
-    val txt = CharBitSet.ints2Hex(array)
-    c.Expr[CharBitSet](q"""
-      new fastparse.Utils.CharBitSet(fastparse.Utils.CharBitSet.hex2Ints($txt), $first, $last)
-    """)
-  }
   /**
    * Convert a string to a C&P-able literal. Basically
    * copied verbatim from the uPickle source code.


### PR DESCRIPTION
FuncName and its companion was nested inside Util, and the companion referred to reflection types. This caused run-time references to FuncName to cause class-loading of the reflection classes, which shouldn't be needed or even available at run-time.

I've fixed this by lifting FuncName up to the top level so that it no longer can potentially trigger a class-load of Utils as its outer class. I've also moved the impl function that implements the FuncName summoning macro out of the FuncName companion into Utils, again so that all the FuncName bytecode can be loaded without triggering loading of reflection.