### PR TITLE
Use CharSequence instead of String for more flexibility

### DIFF
--- a/demo/src/main/scala/demo/DemoMain.scala
+++ b/demo/src/main/scala/demo/DemoMain.scala
@@ -1,6 +1,7 @@
 package demo
 
 import fastparse.all._
+import fastparse.Utils.CharSequenceSlice
 import org.scalajs.dom
 import org.scalajs.dom.html
 

--- a/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
+++ b/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
@@ -35,9 +35,9 @@ case class SyntaxError(failure: Result.Failure) extends Exception{
 }
 
 object SyntaxError{
-  def msg(code: String, expected: String, idx: Int) = {
+  def msg(code: CharSequence, expected: String, idx: Int) = {
     val locationString = {
-      val (first, last) = code.splitAt(idx)
+      val (first, last) = code.toString.splitAt(idx)
       val lastSnippet = last.split('\n').headOption.getOrElse("")
       val firstSnippet = first.reverse.split('\n').lift(0).getOrElse("").reverse
       firstSnippet + lastSnippet + "\n" + (" " * firstSnippet.length) + "^"
@@ -67,7 +67,7 @@ object Result{
    * @param index The index in the parse where this parse failed
    * @param lastParser The deepest parser in the parse which failed
    */
-  case class Failure(input: String,
+  case class Failure(input: CharSequence,
                      index: Int,
                      lastParser: Parser[_],
                      traceData: (Int, Parser[_])) extends Result[Nothing]{
@@ -84,7 +84,7 @@ object Result{
       Precedence.opWrap(p, Precedence.`:`) + ":" + i
     }
     def formatStackTrace(stack: Seq[Frame],
-                          input: String,
+                          input: CharSequence,
                           index: Int,
                           last: String) = {
       val body =
@@ -119,7 +119,7 @@ object Result{
    * @param traceParsers A list of parsers that could have succeeded at the location
    *                     that this
    */
-  case class TracedFailure(input: String,
+  case class TracedFailure(input: CharSequence,
                            index: Int,
                            fullStack: List[Frame],
                            traceParsers: List[Parser[_]]){
@@ -153,7 +153,7 @@ object Result{
     }
   }
   object TracedFailure{
-    def apply(input: String, index: Int, lastParser: Parser[_], traceData: (Int, Parser[_])) = {
+    def apply(input: CharSequence, index: Int, lastParser: Parser[_], traceData: (Int, Parser[_])) = {
       val (originalIndex, originalParser) = traceData
 
       val mutFailure = originalParser.parseRec(
@@ -234,7 +234,7 @@ object Mutable{
    *                     contains sub-parsers, you should generally aggregate
    *                     any the [[traceParsers]] of any of their results.
    */
-  case class Failure(var input: String,
+  case class Failure(var input: CharSequence,
                      var fullStack: List[Frame],
                      var index: Int,
                      var lastParser: Parser[_],
@@ -261,7 +261,7 @@ object Mutable{
  *                   reporting. `-1` disables tracing, and any other number
  *                   enables recording of stack-traces and
  */
-class ParseCtx(val input: String,
+class ParseCtx(val input: CharSequence,
                var logDepth: Int,
                val traceIndex: Int,
                val originalParser: Parser[_],
@@ -301,7 +301,7 @@ trait Parser[+T] extends ParserResults[T] with Precedence{
    *                   invocations to locate bottlenecks or unwanted
    *                   backtracking in the parser.
    */
-  def parse(input: String,
+  def parse(input: CharSequence,
             index: Int = 0,
             instrument: (Parser[_], Int, () => Result[_]) => Unit = null)
             : Result[T] = {

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
@@ -23,7 +23,7 @@ object Combinators {
         case Mutable.Success(value0, index0, traceParsers0, cut0) =>
           success(
             cfg.success,
-            cfg.input.substring(index, index0),
+            cfg.input.subSequence(index, index0).toString,
             index0,
             traceParsers0,
             cut0

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Intrinsics.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Intrinsics.scala
@@ -3,6 +3,7 @@ import acyclic.file
 import fastparse.Utils._
 import fastparse.core.{Precedence, ParseCtx, Result, Parser}
 import fastparse.Utils
+import scala.util.Try
 
 /**
  * High-performance intrinsics for parsing common patterns. All
@@ -16,8 +17,8 @@ object Intrinsics {
     private[this] val uberSet = CharBitSet(chars)
     def parseRec(cfg: ParseCtx, index: Int) = {
       val input = cfg.input
-      if (index >= input.length) fail(cfg.failure, index)
-      else if (uberSet(input(index))) success(cfg.success, (), index + 1, Nil, false)
+      if (Try(input.charAt(index)).isFailure) fail(cfg.failure, index)
+      else if (uberSet(input.charAt(index))) success(cfg.success, (), index + 1, Nil, false)
       else fail(cfg.failure, index)
     }
   }
@@ -44,7 +45,7 @@ object Intrinsics {
     def parseRec(cfg: ParseCtx, index: Int) = {
       var curr = index
       val input = cfg.input
-      while(curr < input.length && uberSet(input(curr))) curr += 1
+      while(curr < input.length && uberSet(input.charAt(curr))) curr += 1
       if (curr - index < min) fail(cfg.failure, curr)
       else success(cfg.success, (), curr, Nil, false)
     }

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Terminals.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Terminals.scala
@@ -3,6 +3,7 @@ import acyclic.file
 import fastparse.Utils._
 import fastparse.core.ParseCtx
 
+import scala.util.Try
 import scala.annotation.tailrec
 import fastparse.core.Parser
 /**
@@ -31,7 +32,7 @@ object Terminals {
     def parseRec(cfg: ParseCtx, index: Int) = {
       val input = cfg.input
       if (index >= input.length) fail(cfg.failure, index)
-      else success(cfg.success, input(index), index+1, Nil, false)
+      else success(cfg.success, input.charAt(index), index+1, Nil, false)
     }
   }
 
@@ -58,7 +59,7 @@ object Terminals {
    * Workaround https://github.com/scala-js/scala-js/issues/1603
    * by implementing startsWith myself
    */
-  def startsWith(src: String, prefix: String, offset: Int) = {
+  def startsWith(src: CharSequence, prefix: String, offset: Int) = {
     val max = prefix.length
     @tailrec def rec(i: Int): Boolean = {
       if (i >= prefix.length) true
@@ -69,7 +70,7 @@ object Terminals {
     rec(0)
   }
 
-  def startsWithIgnoreCase(src: String, prefix: String, offset: Int) = {
+  def startsWithIgnoreCase(src: CharSequence, prefix: String, offset: Int) = {
     val max = prefix.length
     @tailrec def rec(i: Int): Boolean = {
       if (i >= prefix.length) true
@@ -114,8 +115,8 @@ object Terminals {
   case class CharLiteral(c: Char) extends Parser[Unit]{
     def parseRec(cfg: ParseCtx, index: Int) = {
       val input = cfg.input
-      if (index >= input.length) fail(cfg.failure, index)
-      else if (input(index) == c) success(cfg.success, c.toString, index + 1, Nil, false)
+      if (Try(input.charAt(index)).isFailure) fail(cfg.failure, index)
+      else if (input.charAt(index) == c) success(cfg.success, c.toString, index + 1, Nil, false)
       else fail(cfg.failure, index)
     }
     override def toString = literalize(c.toString).toString

--- a/fastparse/shared/src/test/scala/fastparse/IndentationTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/IndentationTests.scala
@@ -34,7 +34,7 @@ object IndentationTests extends TestSuite{
   val expr = new Parser(indent = 0).expr
   val tests = TestSuite{
     'pass {
-      def check(str: String, num: Int) = {
+      def check(str: CharSequence, num: Int) = {
         val Result.Success(value, _) = expr.parse(str)
         assert(value == num)
       }
@@ -119,7 +119,7 @@ object IndentationTests extends TestSuite{
       )
     }
     'fail{
-      def check(input: String, expectedTrace: String) = {
+      def check(input: CharSequence, expectedTrace: String) = {
         val failure = expr.parse(input).asInstanceOf[Result.Failure]
         val actualTrace = failure.traced.trace
         assert(expectedTrace.trim == actualTrace.trim)

--- a/fastparse/shared/src/test/scala/fastparse/JsonTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/JsonTests.scala
@@ -124,7 +124,7 @@ object JsonTests extends TestSuite{
       """)
     }
     'fail{
-      def check(s: String, expectedError: String) = {
+      def check(s: CharSequence, expectedError: String) = {
         jsonExpr.parse(s) match{
           case s: Result.Success[_] => throw new Exception("Parsing should have failed:")
           case f: Result.Failure =>

--- a/fastparse/shared/src/test/scala/fastparse/WhiteSpaceMathTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/WhiteSpaceMathTests.scala
@@ -30,7 +30,7 @@ object WhiteSpaceMathTests extends TestSuite{
 
   val tests = TestSuite{
     'pass {
-      def check(str: String, num: Int) = {
+      def check(str: CharSequence, num: Int) = {
         val Result.Success(value, _) = expr.parse(str)
         assert(value == num)
       }
@@ -44,7 +44,7 @@ object WhiteSpaceMathTests extends TestSuite{
       * - check("((1+      1*2)+(3*4*5))/3", 21)
     }
     'fail{
-      def check(input: String, expectedTrace: String) = {
+      def check(input: CharSequence, expectedTrace: String) = {
         val failure = expr.parse(input).asInstanceOf[Result.Failure]
         val actualTrace = failure.traced.trace
         assert(expectedTrace.trim == actualTrace.trim)

--- a/scalaparse/shared/src/test/scala/scalaparse/TestUtil.scala
+++ b/scalaparse/shared/src/test/scala/scalaparse/TestUtil.scala
@@ -6,12 +6,13 @@ import utest._
 
 
 import scalaparse.Scala._
+import Utils.CharSequenceSlice
 
 /**
  * Created by haoyi on 5/3/15.
  */
 object TestUtil {
-  def checkNeg[T](input: String, expected: String = "ADA???D", found: String = "ADQW??") = {
+  def checkNeg[T](input: CharSequence, expected: String = "ADA???D", found: String = "ADQW??") = {
 //    println("Checking Neg...\n" )
 //    println(input)
     Scala.CompilationUnit.parse(input) match{
@@ -29,7 +30,7 @@ object TestUtil {
     }
   }
 
-  def check[T](input: String, tag: String = "") = {
+  def check[T](input: CharSequence, tag: String = "") = {
 //    println("Checking...\n" )
 //    println(input)
     val res = Scala.CompilationUnit.parse(input)

--- a/utils/shared/src/main/scala/fastparse/Utils.scala
+++ b/utils/shared/src/main/scala/fastparse/Utils.scala
@@ -51,7 +51,7 @@ object Utils {
    * Convert a string to a C&P-able literal. Basically
    * copied verbatim from the uPickle source code.
    */
-  def literalize(s: String, unicode: Boolean = true) = {
+  def literalize(s: CharSequence, unicode: Boolean = true) = {
     val sb = new StringBuilder
     sb.append('"')
     var i = 0
@@ -73,6 +73,22 @@ object Utils {
     }
     sb.append('"')
 
+  }
+
+  implicit class CharSequenceSlice(val cs: CharSequence) extends AnyVal{
+    def slice(from: Int, until: Int): String = {
+      try{
+        cs.subSequence(from, until).toString
+      } catch {
+        case e: StringIndexOutOfBoundsException =>
+          if(0 <= from && from <= until){          
+            // when asking for more than the cs is long, it should be safe to call .length on the potentially lazy CharSequence
+            val length = cs.length
+            assert(until > length) // should be true now
+            cs.subSequence(from, length).toString
+          } else ""
+      }
+    }
   }
 
   object CharBitSet{
@@ -163,11 +179,11 @@ object Utils {
     /**
      * Returns the length of the matching string, or -1 if not found
      */
-    def query(input: String, index: Int): Int = {
+    def query(input: CharSequence, index: Int): Int = {
       @tailrec def rec(offset: Int, currentNode: TrieNode, currentRes: Int): Int = {
         if (index + offset >= input.length) currentRes
         else {
-          val char = input(index + offset)
+          val char = input.charAt(index + offset)
           val next = currentNode(char)
           if (next == null) currentRes
           else rec(


### PR DESCRIPTION
This e.g. allows using a lazy sequence for streamed parsing. Replaced eager .length calls with less eager charAt calls where needed. Added test that asserts laziness.

fixes #18