### PR TITLE
Added example of `NoCut` to documentation.

### DIFF
--- a/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
@@ -278,6 +278,27 @@ object ExampleTests extends TestSuite{
           failure.traced.trace == """tuple:0 / digits:3 / CharIn("0123456789"):3 ...")""""
         )
       }
+      'composecut{
+         val digit = P( CharIn('0' to '9') )
+         val time1 = P(("1".? ~ digit) ~ ":" ~! digit ~ digit ~ ("am" | "pm"))
+         val time2 = P((("1" | "2").? ~ digit) ~ ":" ~! digit ~ digit)
+         val Result.Success((), _) = time1.parse("12:30pm")
+         val Result.Success((), _) = time2.parse("17:45")
+         val time = P(time1 | time2)
+         val Result.Success((), _) = time.parse("12:30pm")
+         val failure = time.parse("17:45").asInstanceOf[Result.Failure]
+         assert(failure.index == 5)  // Expects am or pm
+      }
+      'composenocut{
+         val digit = P( CharIn('0' to '9') )
+         val time1 = P(("1".? ~ digit) ~ ":" ~! digit ~ digit ~ ("am" | "pm"))
+         val time2 = P((("1" | "2").? ~ digit) ~ ":" ~! digit ~ digit)
+         val Result.Success((), _) = time1.parse("12:30pm")
+         val Result.Success((), _) = time2.parse("17:45")
+         val time = P(NoCut(time1) | time2)
+         val Result.Success((), _) = time.parse("12:30pm")
+         val Result.Success((), _) = time.parse("17:45")
+      }
     }
     'debugging{
       def check(a: Any, s: String) = assert(a.toString == s.trim)

--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -296,6 +296,16 @@
                     With a cut, the error is improved:
 
                 @hl.ref(tests/"ExampleTests.scala", Seq("'delimitercut", ""))
+            @sect{Isolating Cuts}
+                @p
+                    Because cuts prevent backtracking throughout the entire parser, they make it difficult to compose arbitrary parsers.
+
+                @hl.ref(tests/"ExampleTests.scala", Seq("'composecut", ""))
+
+                @p
+                    To explicitly isolate a cut to one branch of a parser, place that branch within @hl.scala{NoCut}.  Cuts within that branch will prevent backtracking inside that branch, but if that branch fails alternate branches will be tried as normal.
+
+                @hl.ref(tests/"ExampleTests.scala", Seq("'composenocut", ""))
 
     @sect{Example Parsers}
         @p


### PR DESCRIPTION
This ought to document the use of `NoCut` to enable better composition of independently written parsers.  ("Ought to" because not all tests run as I'm not set up for scala.js, and I am entirely unfamiliar with Scalatex.)