### PR TITLE
f.c.R.Failure.formatParser throws an exception on an empty input string

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
+++ b/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
@@ -90,7 +90,7 @@ object Result{
     def formatParser(p: Precedence, input: String, index: Int) = {
       val lines = input.take(1 + index).lines.toVector
       val line = lines.length 
-      val col = lines.last.length
+      val col = lines.lastOption.map(_.length).getOrElse(0)
       s"${Precedence.opWrap(p, Precedence.`:`)}:${line}:${col}"
     }
     def formatStackTrace(stack: Seq[Frame],

--- a/fastparse/shared/src/test/scala/fastparse/MiscTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/MiscTests.scala
@@ -126,5 +126,10 @@ object MiscTests extends TestSuite{
       }
 
     }
+    'formatParser{
+      assert(
+        Result.Failure.formatParser("a", "", 0) == """"a":0:0""",
+        Result.Failure.formatParser("A", "B", 0) == """"A":1:1""")
+    }
   }
 }

--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -775,6 +775,10 @@
             "com.lihaoyi" %%% "scalaparse" % "@fastparse.Constants.version"
 
 @sect{Change Log}
+    @sect{0.3.3}
+        @ul
+            @li
+                @b{#59} Fix @hl.scala{fastparse.core.Result.Failure.formatParser()} throwing @hl.scala{UnsupportedOperationException} on receiving an empty string as an input
     @sect{0.3.2}
         @ul
             @li


### PR DESCRIPTION
fastparse.core.Result.Failure.formatParser() throws an UnsupportedOperationException on receiving an empty string as an input.

```
import fastparse.all._

val p = P("a")
p.parse("")
p.toString // throws
```