### PR TITLE
#66 Bugfix.

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
@@ -402,7 +402,12 @@ object Combinators {
         } else failMore(lastFailure, index, cfg.logDepth, cut = cut)
       }
 
-      rec(index, Pass, null, ev.initial, false, 0)
+      // don't call the parseRec at all, if max is "0", as our parser corresponds to `Pass` in that case.
+      if (max == 0 ) {
+        success(cfg.success, ev.result(ev.initial), index, List.empty[Parser[_]], false)
+      } else {
+        rec(index, Pass, null, ev.initial, false, 0)
+      }
     }
     override def toString = {
       val things = Seq(

--- a/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
@@ -45,6 +45,11 @@ object ParsingTests extends TestSuite{
       check("Hello".!.rep(1, max = 1), ("HelloHello!", 0), Success(Seq("Hello"), 5))
       check("Hello".!.rep(1, max = 2), ("HelloHello!", 0), Success(Seq("Hello", "Hello"), 10))
       check("Hello".!.rep(1, max = 2), ("HelloHelloHello!", 0), Success(Seq("Hello", "Hello"), 10))
+
+      check("Hello".!.rep(0, max=0), ("HelloHello!", 0), Success(Seq(), 0))
+      // identical :  check( ("Hello" | Pass).!, ("HelloHello!", 0), Success("Hello", 5))
+      check("Hello".!.rep(0, max=1), ("HelloHello!", 0), Success(Seq("Hello"), 5))
+
       checkFail("Hello".rep(1), ("HelloHello!", 2), 2)
       checkFail("Hello".rep ~ "bye" ~ End, ("HelloHello!", 0), 10)
     }

--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -784,6 +784,9 @@
 @sect{Change Log}
     @sect{0.3.3}
         @ul
+            @li
+                @b{#66} Bugfix: @hl.scala{Parser.rep} now handles max=0 properly. Contributor: @a("Martin Senne", href:="https://github.com/ProjectZetta/")
+
             @li 
                 Further restructuring of @hl.scala{Parsed} including docs - Contributor: @a("Martin Senne", href:="https://github.com/ProjectZetta/")
                 @ul


### PR DESCRIPTION
Please recheck, if last parameter `false` in

    success(cfg.success, ev.result(ev.initial), index, List.empty[Parser[_]], false)

is ok!

Tests (plus additional tests for bugfix) run through.

