### PR TITLE
Do not use lazy mapValues in TrieNode

### DIFF
--- a/fastparse/shared/src/test/scala/fastparse/MiscTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/MiscTests.scala
@@ -146,5 +146,13 @@ object MiscTests extends TestSuite{
         Parsed.Failure.formatParser("a", "", 0) == """"a":0:0""",
         Parsed.Failure.formatParser("A", "B", 0) == """"A":1:1""")
     }
+    'utils{
+      'trieNode {
+        val names = (0 until 1000).map(_.toString.flatMap(_.toString * 5))
+        val trie = new Utils.TrieNode(names)
+        for (name <- names)
+          assert(trie.query(name, 0) != -1)
+      }
+    }
   }
 }

--- a/utils/shared/src/main/scala/fastparse/Utils.scala
+++ b/utils/shared/src/main/scala/fastparse/Utils.scala
@@ -144,7 +144,7 @@ object Utils {
     val (min, max, arr) = {
       val children = strings.filter(!_.isEmpty)
                             .groupBy(_(0))
-                            .mapValues(ss => new TrieNode(ss.map(_.tail)))
+                            .map { case (k,ss) => k -> new TrieNode(ss.map(_.tail)) }
       if (children.size == 0) (0.toChar, 0.toChar, new Array[TrieNode](0))
       else {
         val min = children.keysIterator.min


### PR DESCRIPTION
This seems to make creation of the TrieNode much faster. It might fix #33

https://issues.scala-lang.org/browse/SI-4776

The TrieNode tree seems to be pretty fast once it is created. I compared it with my RadixTree https://github.com/rklaehn/radixtree , which is more optimised for compact storage of very large string sets, and it is doing quite well.

But creation of a TrieNode containing e.g. all words from http://www-01.sil.org/linguistics/wordlists/english/wordlist/wordsEn.txt would not even terminate.