### PR TITLE
expose #77 in test & fix by deduplicating traceParsers on every pass

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/WhitespaceApi.scala
+++ b/fastparse/shared/src/main/scala/fastparse/WhitespaceApi.scala
@@ -24,13 +24,13 @@ object WhitespaceApi {
                                        (implicit ev: Sequencer[T, V, R]) extends P[R] {
     def parseRec(cfg: ParseCtx, index: Int) = {
       p0.parseRec(cfg, index) match {
-        case f: Mutable.Failure => failMore(f, index, cfg.logDepth, f.traceParsers, false)
+        case f: Mutable.Failure => failMore(f, index, cfg.logDepth, f.traceParsers.distinct, false)
         case Mutable.Success(value0, index0, traceParsers0, cut0) =>
           WL.parseRec(cfg, index0) match {
             case f1: Mutable.Failure => failMore(f1, index, cfg.logDepth)
             case Mutable.Success(value1, index1, traceParsers1, cut1) =>
               p.parseRec(cfg, index1) match {
-                case f: Mutable.Failure => failMore(f, index1, cfg.logDepth, traceParsers0 ::: f.traceParsers, cut | cut0)
+                case f: Mutable.Failure => failMore(f, index1, cfg.logDepth, (traceParsers0 ::: f.traceParsers).distinct, cut | cut0)
                 case Mutable.Success(value2, index2, traceParsers2, cut2) =>
                   val (newIndex, newCut) =
                     if (index2 > index1 || index1 == cfg.input.length) (index2, cut | cut0 | cut1 | cut2)
@@ -40,7 +40,7 @@ object WhitespaceApi {
                     cfg.success,
                     ev.apply(value0, value2),
                     newIndex,
-                    traceParsers0 ::: traceParsers2,
+                    (traceParsers0 ::: traceParsers2).distinct,
                     newCut
                   )
               }

--- a/fastparse/shared/src/test/scala/fastparse/GnipSubSyntaxTest.scala
+++ b/fastparse/shared/src/test/scala/fastparse/GnipSubSyntaxTest.scala
@@ -1,0 +1,82 @@
+package fastparse
+
+import utest._
+
+/**
+ * Created by jero on 2-3-16.
+ */
+
+import scala.concurrent.{Await, Future, ExecutionContext}
+import scala.language.postfixOps
+import scala.util.Try
+import scala.util.control.NoStackTrace
+
+/**
+ * Created by jero on 3-2-16.
+ */
+
+
+
+object GnipSubSyntaxTest extends TestSuite {
+  class GnipRuleParser {
+    val White = WhitespaceApi.Wrapper {
+      import fastparse.all._
+      NoTrace(" ".rep)
+    }
+    import fastparse.noApi._
+    import White._
+
+    private val keyword = P(CharIn('a' to 'z')!)
+    private val maybeNegatedKeyword = P((("-"?) ~~ keyword)!)
+
+    private val keywordGroupWithoutOrClause = P((maybeNegatedKeyword | (("-"?) ~~ keywordsInParentheses))!)
+    private val keywordGroup = P(orClause | keywordGroupWithoutOrClause)
+
+    private def keywordsInParentheses = P("(" ~ gnipKeywordPhrase ~ ")")
+    private def orClause = P(!(("-" ~~ keywordGroupWithoutOrClause.rep(min = 1)) ~ "OR") ~ keywordGroupWithoutOrClause ~ ("OR"!) ~ gnipKeywordPhrase)
+    private def gnipKeywordPhrase: Parser[String] = P(keywordGroup.rep(min = 1))!
+
+    def parse(rule: String) = P(Start ~ gnipKeywordPhrase ~ End).parse(rule)
+  }
+
+  object GnipRuleValidator {
+    import fastparse.core.Parsed._
+    import fastparse.core.ParseError
+    import concurrent.duration._
+
+    def apply(rule: String) = (new GnipRuleParser).parse(rule) match {
+      case Success(matched, index) => scala.util.Success(matched)
+      case f @ Failure(_, index, extra) => {
+        implicit val ec = new MyCustomExecutionContext
+        val fut = Future(ParseError(f))
+        Try(Await.result(fut, 1 second)) match {
+          case scala.util.Success(parseError) => scala.util.Failure(parseError)
+          case failure => {
+            Try(ec.lastThread.get.stop())
+            throw new RuntimeException(ParseError.msg(extra.input, "Couldn't determine within 1 second", index)) with NoStackTrace
+          }
+        }
+      }
+    }
+  }
+
+  class MyCustomExecutionContext extends AnyRef with ExecutionContext {
+    @volatile var lastThread: Option[Thread] = None
+    override def execute(runnable: Runnable): Unit = {
+      ExecutionContext.Implicits.global.execute(new Runnable() {
+        override def run() {
+          lastThread = Some(Thread.currentThread)
+          runnable.run()
+        }
+      })
+    }
+    override def reportFailure(t: Throwable): Unit = ???
+  }
+
+  val tests = TestSuite {
+    'fail {
+      assert(GnipRuleValidator("( ab ( cd ( ef ( gh ( ij ( ( hello ( world ) bla ) lol ) hehe ) ) ) xz )").isFailure)
+    }
+
+  }
+}

--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -785,6 +785,8 @@
     @sect{0.3.5}
         @ul
             @li
+                Fix @b{#77}: deduplicate traceParsers in WhitespaceAPI to prevent stack overflow, by @a("Jeroen Rosenberg", href:="https://github.com/jeroenr")
+            @li
                 Minor improvements to error-reporting in Scalaparse; error messages inside tuple-types and refinement-types should be slightly more precise
     @sect{0.3.4}
         @ul


### PR DESCRIPTION
Without the changes to **fastparse/shared/src/main/scala/fastparse/WhitespaceApi.scala** the added test will blow up the stack