### PR TITLE
Added a StringInIgnoreCase parser

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/Api.scala
+++ b/fastparse/shared/src/main/scala/fastparse/Api.scala
@@ -25,6 +25,7 @@ trait Api{
   val CharsWhile = Intrinsics.CharsWhile
   val CharPredicates = fastparse.CharPredicates
   val StringIn = Intrinsics.StringIn
+  val StringInIgnoreCase = Intrinsics.StringInIgnoreCase
 
   val NoTrace = parsers.Combinators.NoTrace
   val NoCut = parsers.Combinators.NoCut

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Intrinsics.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Intrinsics.scala
@@ -56,7 +56,7 @@ object Intrinsics {
    */
   case class StringIn(strings: String*) extends Parser[Unit]{
 
-    private[this] val trie = new TrieNode(strings)
+    private[this] val trie = new TrieNode(strings, false)
 
     def parseRec(cfg: ParseCtx, index: Int) = {
       val length = trie.query(cfg.input, index)
@@ -65,6 +65,25 @@ object Intrinsics {
     }
     override def toString = {
       s"StringIn(${strings.map(literalize(_)).mkString(", ")})"
+    }
+  }
+
+  /**
+   * Very efficiently attempts to parse a set of strings case insensitively, by
+   * first converting it into an array-backed Trie and then walking it once.
+   * If multiple strings match the input, longest match wins.
+   */
+  case class StringInIgnoreCase(strings: String*) extends Parser[Unit]{
+
+    private[this] val trie = new TrieNode(strings, true)
+
+    def parseRec(cfg: ParseCtx, index: Int) = {
+      val length = trie.query(cfg.input, index)
+      if (length != -1) success(cfg.success, (), index + length + 1, Set.empty, false)
+      else fail(cfg.failure, index)
+    }
+    override def toString = {
+      s"StringInIgnoreCase(${strings.map(literalize(_)).mkString(", ")})"
     }
   }
 }

--- a/fastparse/shared/src/test/scala/fastparse/MiscTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/MiscTests.scala
@@ -149,7 +149,7 @@ object MiscTests extends TestSuite{
     'utils{
       'trieNode {
         val names = (0 until 1000).map(_.toString.flatMap(_.toString * 5))
-        val trie = new Utils.TrieNode(names)
+        val trie = new Utils.TrieNode(names, false)
         for (name <- names)
           assert(trie.query(name, 0) != -1)
       }

--- a/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
@@ -91,6 +91,11 @@ object ParsingTests extends TestSuite{
         checkFail(("Hello" ~/ "Bye").?, ("HelloBoo", 0), 5)
       }
     }
+    'stringInIgnoreCase {
+       check(StringInIgnoreCase("Hello", "Hello World"), ("hElLo WOrld!", 0), Success((), 11))
+       check(StringInIgnoreCase("abc","abde","abdgh").!, ("ABCDE", 0), Success(("ABC"), 3))
+       checkFail(StringInIgnoreCase("abc","def","ghi"), ("bcde", 0), 0)
+    }
   }
 }
 

--- a/utils/shared/src/main/scala/fastparse/Utils.scala
+++ b/utils/shared/src/main/scala/fastparse/Utils.scala
@@ -118,12 +118,13 @@ object Utils {
    * An trie node for quickly matching multiple strings which
    * share the same prefix, one char at a time.
    */
-  final class TrieNode(strings: Seq[String]){
+  final class TrieNode(strings: Seq[String], ignoreCase: Boolean){
 
     val (min, max, arr) = {
-      val children = strings.filter(!_.isEmpty)
-                            .groupBy(_(0))
-                            .map { case (k,ss) => k -> new TrieNode(ss.map(_.tail)) }
+      val ignoreCaseStrings = if (ignoreCase) strings.map(_.toLowerCase) else strings
+      val children = ignoreCaseStrings.filter(!_.isEmpty)
+                                      .groupBy(_(0))
+                                      .map { case (k,ss) => k -> new TrieNode(ss.map(_.tail), ignoreCase) }
       if (children.size == 0) (0.toChar, 0.toChar, new Array[TrieNode](0))
       else {
         val min = children.keysIterator.min
@@ -143,6 +144,14 @@ object Utils {
      * Returns the length of the matching string, or -1 if not found
      */
     def query(input: String, index: Int): Int = {
+      if (ignoreCase) {
+        queryInternal(input.toLowerCase, index)
+      } else {
+        queryInternal(input, index)
+      }
+    }
+
+    private def queryInternal(input: String, index: Int): Int = {
       @tailrec def rec(offset: Int, currentNode: TrieNode, currentRes: Int): Int = {
         if (index + offset >= input.length) currentRes
         else {


### PR DESCRIPTION
We're replacing the parser combinators library with fastparse and one thing we're working around is parsing for a set of case insensitive strings. This PR adds that feature with a small change to the StringIn parser, and adds a couple tests.