### PR TITLE
Add a `to` method to the Api

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/Api.scala
+++ b/fastparse/shared/src/main/scala/fastparse/Api.scala
@@ -13,7 +13,8 @@ import fastparse.Utils.HexUtils
 
 class Api[ElemType, Repr]()(implicit elemSetHelper: ElemSetHelper[ElemType],
                             elemFormatter: ElemTypeFormatter[ElemType],
-                            ordering: Ordering[ElemType]) extends ToArityMethods {
+                            ordering: Ordering[ElemType])
+  extends ToArityMethods[ElemType, Repr] {
   type Parsed[+T] = core.Parsed[T, ElemType]
   object Parsed {
     type Failure = core.Parsed.Failure[ElemType]

--- a/fastparse/shared/src/main/scala/fastparse/Api.scala
+++ b/fastparse/shared/src/main/scala/fastparse/Api.scala
@@ -13,7 +13,7 @@ import fastparse.Utils.HexUtils
 
 class Api[ElemType, Repr]()(implicit elemSetHelper: ElemSetHelper[ElemType],
                             elemFormatter: ElemTypeFormatter[ElemType],
-                            ordering: Ordering[ElemType]) {
+                            ordering: Ordering[ElemType]) extends ToArityMethods {
   type Parsed[+T] = core.Parsed[T, ElemType]
   object Parsed {
     type Failure = core.Parsed.Failure[ElemType]

--- a/fastparse/shared/src/main/scala/fastparse/ToArityMethods.scala
+++ b/fastparse/shared/src/main/scala/fastparse/ToArityMethods.scala
@@ -1,0 +1,101 @@
+package fastparse
+
+import parsers.Transformers.Mapper
+import core.Parser
+
+/** Definitions of the `to` method variants for arities up to 22. This trait is meant as a mix-in for [[Api]]
+  * so as to keep the boilerplate out of `Api.scala` itself. */
+trait ToArityMethods {
+  implicit final class To0(val p: Parser[Unit]) {
+    def to[B](f: => B): Parser[B] = Mapper(p, (_: Unit) => f)
+  }
+
+  // This is essentially just an alias for `map`, but it makes a consistent story
+  implicit final class To1[A1](val p: Parser[A1]) {
+    def to[B](f: A1 => B): Parser[B] = Mapper(p, f)
+  }
+
+  implicit final class To2[A1, A2](val p: Parser[(A1, A2)]) {
+    def to[B](f: (A1, A2) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To3[A1, A2, A3](val p: Parser[(A1, A2, A3)]) {
+    def to[B](f: (A1, A2, A3) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To4[A1, A2, A3, A4](val p: Parser[(A1, A2, A3, A4)]) {
+    def to[B](f: (A1, A2, A3, A4) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To5[A1, A2, A3, A4, A5](val p: Parser[(A1, A2, A3, A4, A5)]) {
+    def to[B](f: (A1, A2, A3, A4, A5) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To6[A1, A2, A3, A4, A5, A6](val p: Parser[(A1, A2, A3, A4, A5, A6)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To7[A1, A2, A3, A4, A5, A6, A7](val p: Parser[(A1, A2, A3, A4, A5, A6, A7)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To8[A1, A2, A3, A4, A5, A6, A7, A8](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To9[A1, A2, A3, A4, A5, A6, A7, A8, A9](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To10[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To11[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To12[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To13[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To14[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To15[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To16[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To17[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To18[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To19[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To20[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To21[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+
+  implicit final class To22[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22)]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) => B): Parser[B] = Mapper(p, f.tupled)
+  }
+}

--- a/fastparse/shared/src/main/scala/fastparse/ToArityMethods.scala
+++ b/fastparse/shared/src/main/scala/fastparse/ToArityMethods.scala
@@ -4,98 +4,99 @@ import parsers.Transformers.Mapper
 import core.Parser
 
 /** Definitions of the `to` method variants for arities up to 22. This trait is meant as a mix-in for [[Api]]
-  * so as to keep the boilerplate out of `Api.scala` itself. */
-trait ToArityMethods {
-  implicit final class To0(val p: Parser[Unit]) {
-    def to[B](f: => B): Parser[B] = Mapper(p, (_: Unit) => f)
+  * so as to keep the boilerplate out of `Api.scala` itself.
+  */
+trait ToArityMethods[ElemType, Repr] {
+  implicit final class To0(val p: Parser[Unit, ElemType, Repr]) {
+    def to[B](f: => B): Parser[B, ElemType, Repr] = Mapper(p, (_: Unit) => f)
   }
 
   // This is essentially just an alias for `map`, but it makes a consistent story
-  implicit final class To1[A1](val p: Parser[A1]) {
-    def to[B](f: A1 => B): Parser[B] = Mapper(p, f)
+  implicit final class To1[A1](val p: Parser[A1, ElemType, Repr]) {
+    def to[B](f: A1 => B): Parser[B, ElemType, Repr] = Mapper(p, f)
   }
 
-  implicit final class To2[A1, A2](val p: Parser[(A1, A2)]) {
-    def to[B](f: (A1, A2) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To2[A1, A2](val p: Parser[(A1, A2), ElemType, Repr]) {
+    def to[B](f: (A1, A2) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To3[A1, A2, A3](val p: Parser[(A1, A2, A3)]) {
-    def to[B](f: (A1, A2, A3) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To3[A1, A2, A3](val p: Parser[(A1, A2, A3), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To4[A1, A2, A3, A4](val p: Parser[(A1, A2, A3, A4)]) {
-    def to[B](f: (A1, A2, A3, A4) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To4[A1, A2, A3, A4](val p: Parser[(A1, A2, A3, A4), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To5[A1, A2, A3, A4, A5](val p: Parser[(A1, A2, A3, A4, A5)]) {
-    def to[B](f: (A1, A2, A3, A4, A5) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To5[A1, A2, A3, A4, A5](val p: Parser[(A1, A2, A3, A4, A5), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To6[A1, A2, A3, A4, A5, A6](val p: Parser[(A1, A2, A3, A4, A5, A6)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To6[A1, A2, A3, A4, A5, A6](val p: Parser[(A1, A2, A3, A4, A5, A6), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To7[A1, A2, A3, A4, A5, A6, A7](val p: Parser[(A1, A2, A3, A4, A5, A6, A7)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To7[A1, A2, A3, A4, A5, A6, A7](val p: Parser[(A1, A2, A3, A4, A5, A6, A7), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To8[A1, A2, A3, A4, A5, A6, A7, A8](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To8[A1, A2, A3, A4, A5, A6, A7, A8](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To9[A1, A2, A3, A4, A5, A6, A7, A8, A9](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To9[A1, A2, A3, A4, A5, A6, A7, A8, A9](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To10[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To10[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To11[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To11[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To12[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To12[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To13[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To13[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To14[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To14[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To15[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To15[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To16[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To16[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To17[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To17[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To18[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To18[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To19[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To19[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To20[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To20[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To21[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To21[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 
-  implicit final class To22[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22)]) {
-    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) => B): Parser[B] = Mapper(p, f.tupled)
+  implicit final class To22[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22](val p: Parser[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22), ElemType, Repr]) {
+    def to[B](f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) => B): Parser[B, ElemType, Repr] = Mapper(p, f.tupled)
   }
 }

--- a/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
@@ -206,6 +206,23 @@ object ExampleTests extends TestSuite{
           failure.extra.traced.trace == """xml:1:1 / rightTag:1:8 / "abcde":1:10 ..."edcba>""""
         )
       }
+      'to {
+        case class Foo1(a: String)
+        case class Foo2(a: String, b: String)
+        case class Foo3(a: String, b: String, c: String)
+
+        val Parsed.Success(r0, _i0) = P("foo").to(1).parse("foo")
+        assert(r0 == 1)
+
+        val Parsed.Success(r1, _i1) = P("foo").!.to(Foo1).parse("foo")
+        assert(r1 == Foo1("foo"))
+
+        val Parsed.Success(r2, _i2) = P("foo".! ~ "bar".!).to(Foo2).parse("foobar")
+        assert(r2 == Foo2("foo", "bar"))
+
+        val Parsed.Success(r3, _i3) = P("foo".! ~ "bar".! ~ "baz".!).to(Foo3).parse("foobarbaz")
+        assert(r3 == Foo3("foo", "bar", "baz"))
+      }
       'filter{
         val digits = P(CharIn('0' to '9').rep(1).!).map(_.toInt)
         val even = digits.filter(_ % 2 == 0)


### PR DESCRIPTION
Here's a proposed new method to the Api.

The `to` method is an alternative for `map` that in some cases provides slightly more convenient syntax.

Link to the very short [gitter discussion](https://gitter.im/lihaoyi/fastparse?at=56f7d6f48f5147e119f0df85).

Not sure about the name but this is just a proposal at this point.

TODO:
- [ ] agree on the name and
- [ ] write documentation.