### PR TITLE
changed https to http in documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ FastParse [![Build Status](https://travis-ci.org/lihaoyi/fastparse.svg?branch=ma
 This is where the code for the FastParse parsing library lives! If you want
 to use Fastparse, you probably will want to check out the documentation:
 
-- [Documentation](https://lihaoyi.github.io/fastparse)
+- [Documentation](http://lihaoyi.github.io/fastparse)
 
 This readme contains some developer docs, if you intend on working on the fastparse repo, not just using it as a library.
 


### PR DESCRIPTION
My browser told be that the https connection is secure and I could not enter the documentation through that link, so I changed it to an http link that works nicely. I think having http instead of https for documentation is something most people can live with.