### PR TITLE
Strange usage of Pass in scalaparse

### DIFF
--- a/scalaparse/shared/src/main/scala/scalaparse/Types.scala
+++ b/scalaparse/shared/src/main/scala/scalaparse/Types.scala
@@ -13,7 +13,7 @@ trait Types extends Core{
     P( (`private` | `protected`) ~ AccessQualifier.? )
   }
   val Dcl: P0 = {
-    P( Pass ~ ((`val` | `var`) ~/ ValVarDef | `def` ~/ FunDef | `type` ~/ TypeDef) )
+    P( (`val` | `var`) ~/ ValVarDef | `def` ~/ FunDef | `type` ~/ TypeDef )
   }
 
   val Mod: P0 = P( LocalMod | AccessMod | `override` )
@@ -42,7 +42,7 @@ trait Types extends Core{
     // or `() => T`! only cut after parsing one type
     val TupleType = P( "(" ~/ Type.rep(sep= ",".~/) ~ ")" )
     val BasicType = P( TupleType | TypeId ~ ("." ~ `type`).? | `_` )
-    P( BasicType ~ (Pass ~ (TypeArgs | `#` ~/ Id)).rep )
+    P( BasicType ~ (TypeArgs | `#` ~/ Id).rep )
   }
 
   val TypeArgs = P( "[" ~/ Type.rep(sep=",".~/) ~ "]" )
@@ -51,12 +51,12 @@ trait Types extends Core{
   val FunSig: P0 = {
     val FunArg = P( Annot.rep ~ Id ~ (`:` ~/ Type).? ~ (`=` ~/ TypeExpr).? )
     val Args = P( FunArg.rep(1, ",".~/) )
-    val FunArgs = P( OneNLMax ~ "(" ~/ (Pass ~ `implicit`).? ~ Args.? ~ ")" )
+    val FunArgs = P( OneNLMax ~ "(" ~/ `implicit`.? ~ Args.? ~ ")" )
     val FunTypeArgs = P( "[" ~/ (Annot.rep ~ TypeArg).rep(1, ",".~/) ~ "]" )
-    P( (Id | `this`) ~ (Pass ~ FunTypeArgs).? ~~ FunArgs.rep )
+    P( (Id | `this`) ~ (FunTypeArgs).? ~~ FunArgs.rep )
   }
 
-  val TypeBounds: P0 = P( (Pass ~ `>:` ~/ Type).? ~ (`<:` ~/ Type).? )
+  val TypeBounds: P0 = P( (`>:` ~/ Type).? ~ (`<:` ~/ Type).? )
   val TypeArg: P0 = {
     val CtxBounds = P((`<%` ~/ Type).rep ~ (`:` ~/ Type).rep)
     P((Id | `_`) ~ TypeArgList.? ~ TypeBounds ~ CtxBounds)


### PR DESCRIPTION
Hi, I asked about usage of `Pass ~` in scalaparse [on gitter](https://gitter.im/lihaoyi/fastparse?at=57a04f31c915a0e426b51aba) some days ago. So I was curious and tried to remove them. Here are those that don't fail tests. But there is still one left in `Types.scala` on the [line 33](https://github.com/laughedelic/fastparse/blob/bdade4a4c22de36264a9e076e402c517557a4087/scalaparse/shared/src/main/scala/scalaparse/Types.scala#L33) and one in `Scala.scala` on the [line 14](https://github.com/laughedelic/fastparse/blob/bdade4a4c22de36264a9e076e402c517557a4087/scalaparse/shared/src/main/scala/scalaparse/Scala.scala#L14). If I remove them some tests fail. 

I don't understand why they were there in the first place and why those two are essential. My guess would be that these two interact somehow with the cuts in `rep`, but it's just a speculation. I would appreciate if somebody who is more familiar with the internals of fastparse explained this. 