### PR TITLE
First pass cleanup of GSOC code

### DIFF
--- a/byteparse/jvm/src/test/scala/byteparse/LargeBmpTests.scala
+++ b/byteparse/jvm/src/test/scala/byteparse/LargeBmpTests.scala
@@ -15,7 +15,7 @@ object LargeBmpTests extends TestSuite {
   val tests = TestSuite {
     'lena {
       val lenaRecource = getClass.getResource("/lena.bmp")
-      val Parsed.Success(lenaBmp, _) = bmp.parse(Files.readAllBytes(Paths.get(lenaRecource.getPath)))
+      val Parsed.Success(lenaBmp, _) = bmp.parse(Files.readAllBytes(Paths.get(lenaRecource.toURI.getPath)))
 
       def compareBmpImg(bmp: Bmp, img: BufferedImage): Unit = {
         assert(bmp.pixels.length == img.getHeight)
@@ -23,9 +23,11 @@ object LargeBmpTests extends TestSuite {
           assert(bmp.pixels(y).length == img.getWidth)
           for (x <- 0 until img.getWidth) {
             val color = new Color(img.getRGB(x, y))
-            assert(color.getRed.toByte == bmp.pixels(y)(x).colors(2) &&
+            assert(
+              color.getRed.toByte == bmp.pixels(y)(x).colors(2) &&
               color.getGreen.toByte == bmp.pixels(y)(x).colors(1) &&
-              color.getBlue.toByte == bmp.pixels(y)(x).colors(0))
+              color.getBlue.toByte == bmp.pixels(y)(x).colors(0)
+            )
           }
         }
       }
@@ -39,14 +41,18 @@ object LargeBmpTests extends TestSuite {
 
       'mirrored {
         val mirroredLenaImg = readImg("mirrored_lena.bmp")
-        val mirroredBmp = Bmp(lenaBmp.fileHeader, lenaBmp.bitmapHeader, lenaBmp.pixels.map(_.reverse))
+        val mirroredBmp = Bmp(
+          lenaBmp.fileHeader, lenaBmp.bitmapHeader, lenaBmp.pixels.map(_.reverse)
+        )
         compareBmpImg(mirroredBmp, mirroredLenaImg)
       }
 
       'inverted {
         val invertedLenaImg = readImg("inverted_lena.bmp")
-        val invertedBmp = Bmp(lenaBmp.fileHeader, lenaBmp.bitmapHeader,
-                              lenaBmp.pixels.map(_.map(p => Pixel(p.colors.map(b => (-b - 1).toByte)))))
+        val invertedBmp = Bmp(
+          lenaBmp.fileHeader, lenaBmp.bitmapHeader,
+          lenaBmp.pixels.map(_.map(p => Pixel(p.colors.map(b => (-b - 1).toByte))))
+        )
         compareBmpImg(invertedBmp, invertedLenaImg)
       }
     }

--- a/byteparse/shared/src/main/scala/byteparse/BmpParser.scala
+++ b/byteparse/shared/src/main/scala/byteparse/BmpParser.scala
@@ -29,16 +29,34 @@ object BmpParser {
   import BmpAst._
   import ByteUtils.LE._
 
-  val fileHeader = P( AnyWordI /*headerType*/ ~ AnyDwordI /*size*/ ~
-    AnyWord ~ AnyWord ~
-    AnyDwordI /*offset*/ ).map(s => FileHeader.tupled(s))
+  val fileHeader = {
+    val headerType = AnyWordI
+    val size = AnyDwordI
+    val offset = AnyDwordI
+    P( headerType ~ size ~ AnyWord ~ AnyWord ~ offset ).map(FileHeader.tupled)
+  }
 
-  val bitmapInfoHeaderPart = P( AnyDwordI /*width*/ ~ AnyDwordI /*height*/ ~
-    AnyWordI /*colorPlanes*/ ~ AnyWordI /*bitsPerPixel*/ ~
-    AnyDwordI /*compression*/ ~ AnyDwordI /*imageSize*/ ~
-    AnyDwordI /*horzRes*/ ~ AnyDwordI /*vertRes*/ ~
-    AnyDwordI /*colorUsed*/ ~ AnyDwordI /*colorsImportant*/ ).map(
-    s => BitmapInfoHeader(BitmapInfoHeaderPart.tupled(s)))
+  val bitmapInfoHeaderPart = {
+    val width = AnyDwordI 
+    val height = AnyDwordI
+    val colorPlanes = AnyWordI
+    val bitsPerPixel = AnyWordI
+    val compression = AnyDwordI
+    val imageSize = AnyDwordI
+    val horzRes = AnyDwordI
+    val vertRes = AnyDwordI
+    val colorUsed = AnyDwordI
+    val colorsImportant = AnyDwordI
+    P(
+      width ~ height ~
+      colorPlanes ~ bitsPerPixel ~
+      compression ~ imageSize ~
+      horzRes ~ vertRes ~
+      colorUsed ~ colorsImportant
+    ).map(
+      s => BitmapInfoHeader(BitmapInfoHeaderPart.tupled(s))
+    )
+  }
 
   val bitmapV2HeaderPart = {
     val RgbPart = P( AnyByte.rep(exactly=4) )

--- a/byteparse/shared/src/main/scala/byteparse/classparse/ClassParser.scala
+++ b/byteparse/shared/src/main/scala/byteparse/classparse/ClassParser.scala
@@ -178,7 +178,8 @@ object ClassParser {
             case fr: FieldRefInfo => FieldRef(classInfo, fr)
             case mr: MethodRefInfo => MethodRef(classInfo, mr)
             case imr: InterfaceMethodRefInfo => InterfaceMethodRef(classInfo, imr)
-          })
+          }
+        )
     }
 
     case class MethodType(descriptor: String) extends PoolItem
@@ -362,13 +363,17 @@ object ClassParser {
   }
 
   val constantIntInfo = P( BS(3) ~/ AnyDword.! ).map(bs =>
-    BasicElemInfo(IntElem(wrapByteBuffer(bs).getInt)))
+    BasicElemInfo(IntElem(wrapByteBuffer(bs).getInt))
+  )
   val constantFloatInfo = P( BS(4) ~/ AnyDword.! ).map(bs =>
-    BasicElemInfo(FloatElem(wrapByteBuffer(bs).getFloat)))
+    BasicElemInfo(FloatElem(wrapByteBuffer(bs).getFloat))
+  )
   val constantLongInfo = P( BS(5) ~/ AnyByte.rep(exactly=8).! ).map(bs =>
-    BasicElemInfo(LongElem(wrapByteBuffer(bs).getLong)))
+    BasicElemInfo(LongElem(wrapByteBuffer(bs).getLong))
+  )
   val constantDoubleInfo = P( BS(6) ~/ AnyByte.rep(exactly=8).! ).map(bs =>
-    BasicElemInfo(DoubleElem(wrapByteBuffer(bs).getDouble)))
+    BasicElemInfo(DoubleElem(wrapByteBuffer(bs).getDouble))
+  )
 
   val constantNameAndTypeInfo = {
     val name_index = AnyWordI
@@ -454,10 +459,12 @@ object ClassParser {
     val methods = repeatWithSize(methodInfo.~/)
     val attributes = repeatWithSize(attributeInfo.~/)
 
-    P(BS(0xCA, 0xFE, 0xBA, 0xBE) ~/
+    P(
+      BS(0xCA, 0xFE, 0xBA, 0xBE) ~/
       minor_version ~ major_version ~ constant_pool ~
       access_flags ~  this_class ~    super_class ~
-      interfaces ~    fields ~        methods ~       attributes ).map(ClassFileInfo.tupled)
+      interfaces ~    fields ~        methods ~       attributes
+    ).map(ClassFileInfo.tupled)
   }
 
 }

--- a/byteparse/shared/src/test/scala/byteparse/BmpTests.scala
+++ b/byteparse/shared/src/test/scala/byteparse/BmpTests.scala
@@ -35,16 +35,26 @@ object BmpTests extends TestSuite {
 
         val Parsed.Success(bmp1, _) = bmp.parse(file1)
 
-        assert(compareBmps(bmp1,
-                         Bmp(FileHeader(19778, 70, 54),
-                             BitmapInfoHeader(BitmapInfoHeaderPart(2, 2, 1, 24, 0, 16, 2835, 2835, 0, 0)),
-                             ArrayBuffer(ArrayBuffer(
-                               Pixel(BS(0xff, 0, 0)),
-                               Pixel(BS(0, 0xff, 0))),
-                             ArrayBuffer(
-                               Pixel(BS(0, 0, 0xff)),
-                               Pixel(BS(0xff, 0xff, 0xff)))))))
-        }
+        assert(
+          compareBmps(
+            bmp1,
+            Bmp(
+              FileHeader(19778, 70, 54),
+              BitmapInfoHeader(BitmapInfoHeaderPart(2, 2, 1, 24, 0, 16, 2835, 2835, 0, 0)),
+              ArrayBuffer(
+                ArrayBuffer(
+                  Pixel(BS(0xff, 0, 0)),
+                  Pixel(BS(0, 0xff, 0))
+                ),
+                ArrayBuffer(
+                  Pixel(BS(0, 0, 0xff)),
+                  Pixel(BS(0xff, 0xff, 0xff))
+                )
+              )
+            )
+          )
+        )
+      }
 
       'example2 {
         val file1 = strToBytes(
@@ -59,19 +69,29 @@ object BmpTests extends TestSuite {
 
         val Parsed.Success(bmp2, _) = bmp.parse(file1)
 
-        assert(compareBmps(bmp2,
-                           Bmp(FileHeader(19778, 154, 122),
-                               BitmapInfoHeader(BitmapInfoHeaderPart(4, 2, 1, 32, 3, 32, 2835, 2835, 0, 0)),
-                               ArrayBuffer(ArrayBuffer(
-                                 Pixel(BS(0xff, 0, 0, 0xff)),
-                                 Pixel(BS(0, 0xff, 0, 0xff)),
-                                 Pixel(BS(0, 0, 0xff, 0xff)),
-                                 Pixel(BS(0xff, 0xff, 0xff, 0xff))),
-                              ArrayBuffer(
-                                 Pixel(BS(0xff, 0, 0, 0x7f)),
-                                 Pixel(BS(0, 0xff, 0, 0x7f)),
-                                 Pixel(BS(0, 0, 0xff, 0x7f)),
-                                 Pixel(BS(0, 0, 0xff, 0x7f)))))))
+        assert(
+          compareBmps(
+            bmp2,
+            Bmp(
+              FileHeader(19778, 154, 122),
+              BitmapInfoHeader(BitmapInfoHeaderPart(4, 2, 1, 32, 3, 32, 2835, 2835, 0, 0)),
+              ArrayBuffer(
+                ArrayBuffer(
+                  Pixel(BS(0xff, 0, 0, 0xff)),
+                  Pixel(BS(0, 0xff, 0, 0xff)),
+                  Pixel(BS(0, 0, 0xff, 0xff)),
+                  Pixel(BS(0xff, 0xff, 0xff, 0xff))
+                ),
+                ArrayBuffer(
+                  Pixel(BS(0xff, 0, 0, 0x7f)),
+                  Pixel(BS(0, 0xff, 0, 0x7f)),
+                  Pixel(BS(0, 0, 0xff, 0x7f)),
+                  Pixel(BS(0, 0, 0xff, 0x7f))
+                )
+              )
+            )
+          )
+        )
       }
     }
   }

--- a/cssparse/jvm/src/test/scala/cssparse/ProjectTests.scala
+++ b/cssparse/jvm/src/test/scala/cssparse/ProjectTests.scala
@@ -17,8 +17,11 @@ object ProjectTests extends TestSuite {
       println("DOWNLOADING")
       Seq("wget", url, "-O", "target/files/" + name).!
     }
-    val css = new String(java.nio.file.Files.readAllBytes(
-      java.nio.file.Paths.get("target", "files", name)))
+    val css = new String(
+      java.nio.file.Files.readAllBytes(
+        java.nio.file.Paths.get("target", "files", name)
+      )
+    )
     TestUtil.checkParsing(css, tag = name)
     TestUtil.checkPrinting(css, tag = name)
   }

--- a/cssparse/shared/src/main/scala/cssparse/CssParser.scala
+++ b/cssparse/shared/src/main/scala/cssparse/CssParser.scala
@@ -80,10 +80,12 @@ object CssTokensParser {
   val prefixMatchToken =    P( "^=" ).map{ _ => Ast.PrefixMatchToken()}
   val suffixMatchToken =    P( "$=" ).map{_ => Ast.SuffixMatchToken()}
   val substringMatchToken = P( "*=" ).map{_ => Ast.SubstringMatchToken()}
-  val matchToken = P( includeMatchToken | dashMatchToken |
-                       prefixMatchToken  | suffixMatchToken |
-                       suffixMatchToken  | substringMatchToken |
-                       substringMatchToken)
+  val matchToken = P(
+    includeMatchToken | dashMatchToken |
+    prefixMatchToken  | suffixMatchToken |
+    suffixMatchToken  | substringMatchToken |
+    substringMatchToken
+  )
 
   val columnToken =          P( "||" ).map{_ => Ast.ColumnToken()}
   val CDOToken =             P( "<!--" ).map{_ => Ast.CdoToken()}
@@ -100,10 +102,11 @@ object CssTokensParser {
     unicodeRangeToken   | percentageToken |
     dimensionToken      | urlToken |
     numberToken         | identToken |
-    delimToken ).map{
-      case st: Ast.SimpleToken => Some(st)
-      case _ => None
-    }
+    delimToken
+  ).map{
+    case st: Ast.SimpleToken => Some(st)
+    case _ => None
+  }
 
   val bracketsBlock =       P( "(" ~ componentValue.rep ~ ")" ).map(values => Ast.BracketsBlock(values.flatten))
   val curlyBracketsBlock =  P( "{" ~ componentValue.rep ~ "}" ).map(values => Ast.CurlyBracketsBlock(values.flatten))

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Terminals.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Terminals.scala
@@ -77,7 +77,6 @@ object Terminals {
    * by implementing startsWith myself
    */
   def startsWith[ElemType](src: ParserInput[ElemType], prefix: IndexedSeq[ElemType], offset: Int) = {
-    val max = prefix.length
     @tailrec def rec(i: Int): Boolean = {
       if (i >= prefix.length) true
       else if (!src.isReachable(i + offset)) false

--- a/perftests/jvm/src/test/scala/perftests/ByteParse.scala
+++ b/perftests/jvm/src/test/scala/perftests/ByteParse.scala
@@ -7,16 +7,18 @@ import utest._
 
 object ByteParse extends TestSuite {
   val lenaRecource = getClass.getResource("/lena.bmp")
-  val lenaSource = Files.readAllBytes(Paths.get(lenaRecource.getPath))
+  val lenaSource = Files.readAllBytes(Paths.get(lenaRecource.toURI.getPath))
   def lenaIterator(size: Int) = lenaSource.grouped(size)
   val parser = byteparse.BmpParser.bmp
 
   val tests = TestSuite {
     'Lena {
-      Utils.benchmarkAll("ByteParse",
+      Utils.benchmarkAll(
+        "ByteParse",
         parser,
         lenaSource, None,
-        lenaIterator)
+        lenaIterator
+      )
     }
   }
 }

--- a/perftests/jvm/src/test/scala/perftests/ClassParse.scala
+++ b/perftests/jvm/src/test/scala/perftests/ClassParse.scala
@@ -8,14 +8,16 @@ import utest._
 
 object ClassParse extends TestSuite {
   val collisionResource = getClass.getResource("/CollisionJNI.class")
-  val collisionSource = Files.readAllBytes(Paths.get(collisionResource.getPath))
+  val collisionSource = Files.readAllBytes(Paths.get(collisionResource.toURI.getPath))
   def collisionIterator(size: Int) = collisionSource.grouped(size)
   val parser = ClassParser.classFile
 
   val tests = TestSuite {
-    Utils.benchmarkAll("ClassParse",
+    Utils.benchmarkAll(
+      "ClassParse",
       parser,
       collisionSource, None,
-      collisionIterator)
+      collisionIterator
+    )
   }
 }

--- a/perftests/jvm/src/test/scala/perftests/CssParse.scala
+++ b/perftests/jvm/src/test/scala/perftests/CssParse.scala
@@ -10,10 +10,12 @@ object CssParse extends TestSuite {
 
   val tests = TestSuite {
     'Bootstrap {
-      Utils.benchmarkAll("CssParse",
+      Utils.benchmarkAll(
+        "CssParse",
         parser,
         bootstrapSource, None,
-        bootstrapIterator)
+        bootstrapIterator
+      )
     }
   }
 }

--- a/perftests/jvm/src/test/scala/perftests/PythonParse.scala
+++ b/perftests/jvm/src/test/scala/perftests/PythonParse.scala
@@ -10,10 +10,12 @@ object PythonParse extends TestSuite {
 
   val tests = TestSuite {
     'CrossValidation {
-      Utils.benchmarkAll("PythonParse",
+      Utils.benchmarkAll(
+        "PythonParse",
         parser,
         crossValidationSource, Some("def " + crossValidationSource),
-        crossValidationIterator)
+        crossValidationIterator
+      )
     }
   }
 }

--- a/perftests/shared/src/main/scala/perftests/Utils.scala
+++ b/perftests/shared/src/main/scala/perftests/Utils.scala
@@ -91,9 +91,13 @@ object Utils {
                                             converter: ResultConverter[ElemType, Repr]): Unit = {
 
     val results = Utils.benchmark(s"$name Benchmark",
-      Seq(Some(() => parser.parse(data)),
-          dataFailOpt.map(dataFail =>
-            () => parser.parse(dataFail).asInstanceOf[Parsed.Failure[ElemType]].extra.traced)).flatten)
+      Seq(
+        Some(() => parser.parse(data)),
+        dataFailOpt.map(dataFail =>
+          () => parser.parse(dataFail).asInstanceOf[Parsed.Failure[ElemType]].extra.traced
+        )
+      ).flatten
+    )
     println(results.map(_.mkString(" ")).mkString("\n"))
 
     val sizes = Seq(1, 2,/* 4, 16, 64,*/ 1024/*, 4096*/)


### PR DESCRIPTION
- Indent a bunch of parens the way everything else is indented
- Remove one dead statement
- change a bunch of `URL.getPath` to `URL.toURI.getPath` in order to make it work in folders with funny characters (e.g. spaces)

This should make the codebase more consistent and easier for me to work with...

Review by @vovapolu 