### PR TITLE
Improve aggressiveness of dropBuffer calls caused by cuts

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/WhitespaceApi.scala
+++ b/fastparse/shared/src/main/scala/fastparse/WhitespaceApi.scala
@@ -26,7 +26,7 @@ object WhitespaceApi {
       p0.parseRec(cfg, index) match {
         case f: Mutable.Failure[Char] => failMore(f, index, cfg.logDepth, f.traceParsers, false)
         case Mutable.Success(value0, index0, traceParsers0, cut0) =>
-          if (index0 > index && cfg.checkForDrop(cut0)) cfg.input.dropBuffer(index0)
+          if (index0 > index && cfg.checkForDrop(cut0 | cut)) cfg.input.dropBuffer(index0)
 
           val oldCapturing = cfg.isCapturing // completely disallow dropBuffer
           cfg.isCapturing = true

--- a/fastparse/shared/src/main/scala/fastparse/WhitespaceApi.scala
+++ b/fastparse/shared/src/main/scala/fastparse/WhitespaceApi.scala
@@ -46,7 +46,9 @@ object WhitespaceApi {
                 case Mutable.Success(value2, index2, traceParsers2, cut2) =>
                   val (newIndex, newCut) =
                     if (index2 > index1 || !cfg.input.isReachable(index1)) {
-                      if (cfg.checkForDrop(cut | cut0 | cut1 | cut2)) cfg.input.dropBuffer(index2)
+                      if (cfg.checkForDrop(cut | cut0 | cut1 | cut2)) {
+                        cfg.input.dropBuffer(index2)
+                      }
                       (index2, cut | cut0 | cut1 | cut2)
                     } else {
                       (index0, cut | cut0 | cut2)

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
@@ -271,7 +271,8 @@ object Combinators {
                          rCut: Boolean,
                          vIndex: Int,
                          traceParsers: Set[Parser[_, ElemType, _]]): Mutable[R, ElemType] = {
-          if (rIndex > index && cfg.checkForDrop(rCut)) cfg.input.dropBuffer(rIndex)
+          val currParserCut = if (vIndex < ps.length) ps(vIndex).cut else false
+          if (rIndex > index && cfg.checkForDrop(rCut | currParserCut)) cfg.input.dropBuffer(rIndex)
 
           if (vIndex >= ps.length) success(cfg.success, r1, rIndex, traceParsers, rCut)
           else {

--- a/fastparse/shared/src/test/scala/fastparse/iterator/IteratorTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/iterator/IteratorTests.scala
@@ -38,7 +38,7 @@ object IteratorTests extends TestSuite {
       import fastparse.noApi._
       val White = fastparse.WhitespaceApi.Wrapper{
         import fastparse.all._
-        NoTrace(" ".? ~ " ".rep) // note that the whitespace delimiter has cut
+        NoTrace(" ".? ~ " ".rep)
       }
       import White._
       val p = P( "ab" ~/ "cd" | "z" )

--- a/fastparse/shared/src/test/scala/fastparse/iterator/IteratorTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/iterator/IteratorTests.scala
@@ -34,6 +34,21 @@ object IteratorTests extends TestSuite {
       // the cut has taken place, rather than at position 4 as we did earlier.
       assert(input.drops == Set(2, 4))
     }
+    'whitespaceImmediateCutDrop{
+      import fastparse.noApi._
+      val White = fastparse.WhitespaceApi.Wrapper{
+        import fastparse.all._
+        NoTrace(" ".? ~ " ".rep) // note that the whitespace delimiter has cut
+      }
+      import White._
+      val p = P( "ab" ~/ "cd" | "z" )
+
+      val input = toInput("abcdef")
+      val Parsed.Success(res, i) = p.parseInput(input)
+      // Make sure that we drop immediately at position 2, since that is where
+      // the cut has taken place, rather than at position 4 as we did earlier.
+      assert(input.drops == Set(2, 4))
+    }
     'topLevelNoCuts{
       // Top-level sequences, which are not inside any `|`s or `.rep`s or `.?`s,
       // should dropBuffer immediately after every `~`, even without any cuts


### PR DESCRIPTION
In principle, we should be able to call `dropBuffer` immediately after the `lhs` of `lhs ~/ rhs` succeeds, as the cut occurs "in between" the `lhs` and `rhs`. 

Currently, we only call `dropBuffer` after the `rhs` succeeds, as when we're evaluating the "current" `lhs ~/ rhs`, after `lhs` succeeds we decide whether or not to `dropBuffer` based on the *previous* existence of cut, ignoring the fact that a cut had just occurred. Thus, if we had `a ~/ b ~ c`, we would call `dropBuffer` after `b` completes, while we really want it to occur after `a`.

This diff makes the consideration of `dropBuffer` also consider whether the "current" `CustomSequence`/iteration-in-`Sequence.Flat` just performed a cut. Thus, given `a ~/ b ~ c`, we now call `dropBuffer` immediately after `a`, in addition to after `b`.

Also does some miscellaneous changes:

- Convert `LoggedDropsParserInput` to use `SortedSet` and give it a nice
  `toString`, so it's easier to debug things when they misbehave

- Add a unit test to verify that top-level `~`s call `dropBuffer`, even
  without any cuts. This behaves as expected right now, but good to have
  a dedicated test for it

- Add unit tests to verify the new behavior

Tests seem to pass https://travis-ci.org/lihaoyi/fastparse/builds/153880403, at least as-passing-as-they-currently-are

Review by @vovapolu 