### PR TITLE
Speed up Iterator parsers by swapping out Vector for Circular Buffer

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
+++ b/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
@@ -6,6 +6,7 @@ import fastparse.ElemTypeFormatter._
 import fastparse.IndexedParserInput
 
 import scala.collection.mutable
+import scala.reflect.ClassTag
 /**
  * A single frame of the parser call stack
  *
@@ -344,7 +345,8 @@ trait Parser[+T, ElemType, Repr] extends ParserResults[T, ElemType] with Precede
                     index: Int = 0,
                     instrument: (Parser[_, _, _], Int, () => Parsed[_, ElemType]) => Unit = null)
                    (implicit formatter: ElemTypeFormatter[ElemType],
-                             converter: ResultConverter[ElemType, Repr])
+                    converter: ResultConverter[ElemType, Repr],
+                    ct: ClassTag[ElemType])
       : Parsed[T, ElemType] = {
     parseInput(IteratorParserInput(input.map(converter.convertFromRepr)), index, instrument)
   }

--- a/fastparse/shared/src/test/scala/fastparse/IteratorTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/IteratorTests.scala
@@ -3,11 +3,12 @@ package fastparse
 import utest._
 
 import scala.collection.mutable
+import scala.reflect.ClassTag
 
 object IteratorTests extends TestSuite {
 
-  class LoggedDropsParserInput[ElemType](data: Iterator[IndexedSeq[ElemType]])
-                                        (implicit formatter: ElemTypeFormatter[ElemType])
+  class LoggedDropsParserInput[ElemType: ClassTag](data: Iterator[IndexedSeq[ElemType]])
+                                                  (implicit formatter: ElemTypeFormatter[ElemType])
     extends IteratorParserInput[ElemType](data) {
 
     val drops = mutable.SortedSet.empty[Int]

--- a/utils/shared/src/main/scala/fastparse/UberBuffer.scala
+++ b/utils/shared/src/main/scala/fastparse/UberBuffer.scala
@@ -1,0 +1,103 @@
+package fastparse
+
+import scala.reflect.ClassTag
+
+/**
+  * A very fast circular, growable read-write byte buffer.
+  */
+class UberBuffer[T: ClassTag](initSize: Int = 32){ self =>
+  private[this] var data = new Array[T](initSize)
+  private[this] var readPos = 0
+  private[this] var writePos = 0
+
+  def capacity = data.length
+  def apply(index: Int) = {
+    if (index < 0 || index >= length) throw new IndexOutOfBoundsException(
+      s"UberBuffer index $index must be between 0 and $length"
+    )
+    data((index + readPos) % capacity)
+  }
+  def length = {
+    if (writePos == readPos){
+      0
+    }else if(writePos > readPos){
+      //   1 2 3
+      // - - - - -
+      //   r   W
+      //       R
+      writePos - readPos
+    } else {
+      // 3 4   1 2
+      // - - - - -
+      //   W   r
+      //   Rs
+      data.length - readPos + writePos
+    }
+  }
+  private[this] def writeAvailable = {
+    if (writePos == readPos){
+      data.length - 1
+    }else if (writePos > readPos){
+      //    1 2 3 4
+      //  - - - - -
+      //  W R w
+      data.length - writePos - 1 + readPos
+    }else{
+      //    1
+      //  - - - - -
+      //    w W R
+      readPos - writePos - 1
+    }
+  }
+
+  private[this] def expand() = {
+    val newData= new Array[T](data.length * 2)
+
+    if (readPos <= writePos){
+      System.arraycopy(data, readPos, newData, 0, writePos - readPos)
+      writePos = writePos - readPos
+    }else{
+      System.arraycopy(data, readPos, newData, 0, data.length - readPos)
+      System.arraycopy(data, 0, newData, data.length - readPos, writePos)
+      writePos = writePos + data.length - readPos
+    }
+    readPos = 0
+
+    data = newData
+  }
+
+  def write(in: Array[T], offset: Int = 0, length0: Int = -1) = {
+    while (writeAvailable < in.length) expand()
+
+    val (left, right) = in.splitAt(data.length - writePos)
+
+    left.copyToArray(data, writePos)
+    right.copyToArray(data, 0)
+
+    writePos = incr(writePos, in.length)
+  }
+
+
+  def slice(start: Int, end: Int) = {
+    assert(end >= start, s"end:$end must be >= start:$start")
+    val startClamped = math.max(0, start)
+    val endClamped = math.min(length, end)
+    val actualStart = (readPos + startClamped) % data.length
+    val actualEnd = (readPos + endClamped) % data.length
+    val output = new Array[T](endClamped - startClamped)
+    if (actualEnd >= actualStart){
+      System.arraycopy(data, actualStart, output, 0, actualEnd - actualStart)
+    }else{
+      System.arraycopy(data, actualStart, output, 0, data.length - actualStart)
+      System.arraycopy(data, 0, output, data.length - actualStart, actualEnd)
+    }
+    output
+  }
+  def drop(n: Int) = {
+    readPos = incr(readPos, n)
+  }
+
+  private[this] def incr(n: Int, d: Long) = {
+    ((n + d) % data.length).toInt
+  }
+}


### PR DESCRIPTION
Looking up arrays are faster than vectors, copying arrays is faster than copying vectors, mutating arrays is faster than copy-and-updating vectors, and arrays take less memory to store than vectors

JProfiler was showing about 20-30% of time being spent inside various vector operations (lookup, copy-and-update, copy-to-array, ...) and this should make it disappear.

This implements a growable circular buffer to use as a queue, to replace the old var/Vector. As we write stuff to the buffer, we shift the `end` index to the right, wrapping around if there's empty space at the start of the `data` array. As we drop stuff, we simply shift the "start" index from to the right as well, also wrapping around. If the end index ever catches up with the start index, it means the buffer is full and we copy everything to a large array.

This means that the buffer only grows as necessary, and only allocates if it grows. If we are writing/dropping constantly, the two start and end indices will go around and around the data array, but the data array itself will never need to be re-allocated. The buffer only grows and never shrinks, which should be fine for now since it'll never grow much bigger than the input size, and will get discarded once the parse run is complete

Roughly copied from https://github.com/lihaoyi/SprayWebSockets/blob/master/src/main/scala/spray/can/server/websockets/UberBuffer.scala and modified to fit (needs to work on both char/byte, no more input/outputstream API, ...)

This doesn't seem to have much effect on small 1-2 length chunks (maybe even a small slowdown?) but then it seems to have a pretty consistent ~30% speedup on larger chunk sizes. The vector-related bottlenecks also disappeared from the JProfiler profile

# Benchmarks:

I just ran the benchmarks using BmpParse, but presumably it would affect other parsers as well

## Master
| Runs\Chunk | 1           | 2           | 4           | 16          | 64          | 1024        | 4096        | 
|------------|-------------|-------------|-------------|-------------|-------------|-------------|-------------| 
| 1          | 20          | 31          | 35          | 51          | 55          | 60          | 60          | 
| 2          | 27          | 35          | 35          | 55          | 60          | 58          | 59          | 
| 3          | 28          | 33          | 29          | 50          | 56          | 58          | 52          | 
| 4          | 25          | 33          | 33          | 50          | 57          | 55          | 58          | 
| 5          | 27          | 38          | 35          | 56          | 43          | 51          | 55          | 
| Average    | 25.4        | 34          | 33.4        | 52.4        | 54.2        | 56.4        | 56.8        | 
| Std Dev    | 3.20 | 2.64 | 2.60 | 2.88 | 6.53 | 3.50 | 3.27 | 

## Uber Buffer
| Runs\Chunk | 1           | 2           | 4           | 16          | 64          | 1024        | 4096        | 
|------------|-------------|-------------|-------------|-------------|-------------|-------------|-------------| 
| 1          | 20          | 33          | 48          | 76          | 79          | 74          | 79          | 
| 2          | 21          | 33          | 46          | 71          | 80          | 83          | 84          | 
| 3          | 23          | 35          | 45          | 69          | 75          | 77          | 66          | 
| 4          | 17          | 35          | 42          | 68          | 74          | 76          | 72          | 
| 5          | 17          | 31          | 36          | 59          | 67          | 67          | 74          | 
| Average    | 19.6        | 33.4        | 43.4        | 68.6        | 75          | 75.4        | 75          | 
| Std Dev    | 2.60 | 1.67 | 4.66 | 6.18 | 5.14  | 5.77 | 6.85   | 

## Comparison

| Chunk      | 1           | 2           | 4           | 16          | 64          | 1024        | 4096        | 
|------------|-------------|-------------|-------------|-------------|-------------|-------------|-------------| 
| Speedup    | 0.77 | 0.98 | 1.29 | 1.30 | 1.38 | 1.33 | 1.32 | 
