### PR TITLE
Replace the tree-shaped Trie with a flat array-backed Trie with exactly the same behavior.

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/Api.scala
+++ b/fastparse/shared/src/main/scala/fastparse/Api.scala
@@ -6,6 +6,8 @@ import language.experimental.macros
 import fastparse.parsers.{Intrinsics, Terminals}
 import fastparse.Utils.HexUtils
 
+import scala.reflect.ClassTag
+
 /**
  * This is basically a trait which contains
  * the "public" API to fastparse packages
@@ -13,7 +15,9 @@ import fastparse.Utils.HexUtils
 
 class Api[ElemType, Repr]()(implicit elemSetHelper: ElemSetHelper[ElemType],
                             elemFormatter: ElemTypeFormatter[ElemType],
-                            ordering: Ordering[ElemType]) {
+                            ordering: Ordering[ElemType],
+                            numeric: Numeric[ElemType],
+                            ct: ClassTag[ElemType]) {
   type Parsed[+T] = core.Parsed[T, ElemType]
   object Parsed {
     type Failure = core.Parsed.Failure[ElemType]

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Intrinsics.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Intrinsics.scala
@@ -4,6 +4,8 @@ import fastparse.Utils._
 import fastparse.core.{ParseCtx, Parsed, Parser, Precedence}
 import fastparse.{ElemSetHelper, ElemTypeFormatter, Utils}
 
+import scala.reflect.ClassTag
+
 /**
  * High-performance intrinsics for parsing common patterns. All
  * of these have equivalent to constructs that can be put together
@@ -69,14 +71,16 @@ object Intrinsics {
   case class StringIn[ElemType, R](strings: IndexedSeq[ElemType]*)
                                   (implicit formatter: ElemTypeFormatter[ElemType],
                                    helper: ElemSetHelper[ElemType],
-                                   ordering: Ordering[ElemType])
+                                   ordering: Ordering[ElemType],
+                                   numeric: Numeric[ElemType],
+                                   ct: ClassTag[ElemType])
       extends Parser[Unit, ElemType, R] {
 
     private[this] val trie = new TrieNode[ElemType](strings)
 
     def parseRec(cfg: ParseCtx[ElemType], index: Int) = {
       val length = trie.query(cfg.input, index)
-      if (length != -1) success(cfg.success, (), index + length + 1, Set.empty, false)
+      if (length != -1) success(cfg.success, (), index + length, Set.empty, false)
       else fail(cfg.failure, index)
     }
     override def toString = {

--- a/fastparse/shared/src/test/scala/fastparse/MiscTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/MiscTests.scala
@@ -147,12 +147,47 @@ object MiscTests extends TestSuite{
         Parsed.Failure.formatParser("a", IndexedParserInput(""), 0) == """"a":0:0""",
         Parsed.Failure.formatParser("A", IndexedParserInput("B"), 0) == """"A":1:1""")
     }
-    'utils{
-      'trieNode {
+    'trieNode{
+      'basic {
         val names = (0 until 1000).map(_.toString.flatMap(_.toString * 5).toIndexedSeq)
         val trie = new Utils.TrieNode[Char](names)
         for (name <- names)
           assert(trie.query(IndexedParserInput(name), 0) != -1)
+      }
+      'edgeCases{
+        val words = for{
+          a <- 'a' to 'z'
+          b <- 'a' to 'z'
+          c <- 'a' to 'z'
+        } yield s"$a$b$c"
+//        val words = Seq("aaa")
+        val trie = new Utils.TrieNode[Char](words.map(_.toVector))
+        for (word <- words){
+          assert(trie.query(IndexedParserInput(word), 0) == 3)
+          assert(trie.query(IndexedParserInput(word), 1) == -1)
+          assert(trie.query(IndexedParserInput(word.drop(1)), 0) == -1)
+          assert(trie.query(IndexedParserInput(word.dropRight(1)), 0) == -1)
+          assert(trie.query(IndexedParserInput(word + "a_"), 0) == 3)
+          assert(trie.query(IndexedParserInput(word + word.last + "_"), 1) == 3)
+          assert(trie.query(IndexedParserInput(word + word.last + "_"), 2) == -1)
+          assert(trie.query(IndexedParserInput("a_" + word), 0) == -1)
+        }
+      }
+      'overlap{
+        val words = Seq(
+          "abcde",
+          "abc"
+        )
+        val trie = new Utils.TrieNode[Char](words.map(_.toVector))
+        assert(trie.query(IndexedParserInput("abcd"), 0) == 3)
+        val res = trie.query(IndexedParserInput("abcde"), 0)
+        assert(res == 5)
+      }
+      'empty{
+        val words = Seq[String]()
+        val trie = new Utils.TrieNode[Char](words.map(_.toVector))
+        val res = trie.query(IndexedParserInput(""), 0)
+        assert(res == -1)
       }
     }
   }


### PR DESCRIPTION
This was an attempt to speed things up by swapping out the Trie for another implementation. In practice, it didn't seem to make anything faster, but leaving this here because it's interesting and maybe someone could investigate why later