### PR TITLE
Added fold method to Parsed ADT

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
+++ b/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
@@ -32,6 +32,14 @@ sealed trait Parsed[+T, ElemType]{
     case s: Parsed.Success[T, ElemType] => s
     case f: Parsed.Failure[ElemType] => throw new ParseError[ElemType](f)
   }
+
+  /**
+    * Returns the result of $onSuccess if the parsing is successful, otherwise it returns the result of $onFailure
+    */
+  def fold[X](onFailure: (Parser[_, ElemType, _], Int, Parsed.Failure.Extra[ElemType]) => X, onSuccess: (T, Int) => X): X = this match {
+    case Parsed.Success(t, i) => onSuccess(t, i)
+    case f: Parsed.Failure[ElemType] => onFailure(f.lastParser, f.index, f.extra)
+  }
 }
 
 case class ParseError[ElemType](failure: Parsed.Failure[ElemType]) extends Exception(

--- a/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
@@ -454,6 +454,21 @@ object ExampleTests extends TestSuite{
         assert(capturedString == expectedString)
       }
     }
+    'folding{
+      sealed trait AndOr
+      case object And extends AndOr
+      case object Or extends AndOr
+      val and = P(IgnoreCase("And")).map(_ => And)
+      val or = P(IgnoreCase("Or")).map(_ => Or)
+      val andOr = P(and | or)
+
+      def check(input: String, expectedOutput: String) =
+        assert(andOr.parse(input).fold((_, _, _) => s"Cannot parse $input as an AndOr", (v, _) => s"Parsed: $v") == expectedOutput)
+
+      check("AnD", "Parsed: And")
+      check("oR", "Parsed: Or")
+      check("IllegalBooleanOperation", "Cannot parse IllegalBooleanOperation as an AndOr")
+    }
 
   }
 }

--- a/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
@@ -32,6 +32,10 @@ object ParsingTests extends TestSuite{
     }
 
   }
+  def checkFold[T, X](parser: P[T], input: (String, Int), onSuccess: (T, Int) => X, onFailure: (core.Parser[_, Char, _], Int, Parsed.Failure.Extra[Char]) => X, expectedOutput: X): Unit = {
+    val (str, index) = input
+    assert(parser.parse(str, index).fold(onFailure, onSuccess) == expectedOutput)
+  }
   val tests = TestSuite{
 
 
@@ -103,6 +107,14 @@ object ParsingTests extends TestSuite{
         check(("Hello" ~ "Bye").?, ("HelloBoo", 0), Success((), 0))
         checkFail(("Hello" ~/ "Bye").?, ("HelloBoo", 0), 5)
       }
+    }
+    'fold{
+      checkFold("Hello", ("Hello WOrld", 0), (_: Unit, _) => "Parsed", (_, _, _) => "Not Parsed", "Parsed")
+      checkFold("Hello", ("Bye WOrld", 0), (_: Unit, _) => "Parsed", (_, _, _) => "Not Parsed", "Not Parsed")
+      checkFold(("Hello" ~ ("wtf" ~ "omg" | "wtfom")).!, ("Hellowtfom", 0),
+        (v: String, _) => s"Parsed: $v", (_, i, _) => s"Did not parse, failed at index $i", "Parsed: Hellowtfom")
+      checkFold("Hello" ~ ("wtf" ~ "omg" | "bbg"), ("Hellowtfom", 0), (_: Unit, _) => "Parsed",
+        (_, i, _) => s"Did not parse, failed at index $i", "Did not parse, failed at index 5")
     }
   }
 }

--- a/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
@@ -32,10 +32,6 @@ object ParsingTests extends TestSuite{
     }
 
   }
-  def checkFold[T, X](parser: P[T], input: (String, Int), onSuccess: (T, Int) => X, onFailure: (core.Parser[_, Char, _], Int, Parsed.Failure.Extra[Char]) => X, expectedOutput: X): Unit = {
-    val (str, index) = input
-    assert(parser.parse(str, index).fold(onFailure, onSuccess) == expectedOutput)
-  }
   val tests = TestSuite{
 
 
@@ -107,14 +103,6 @@ object ParsingTests extends TestSuite{
         check(("Hello" ~ "Bye").?, ("HelloBoo", 0), Success((), 0))
         checkFail(("Hello" ~/ "Bye").?, ("HelloBoo", 0), 5)
       }
-    }
-    'fold{
-      checkFold("Hello", ("Hello WOrld", 0), (_: Unit, _) => "Parsed", (_, _, _) => "Not Parsed", "Parsed")
-      checkFold("Hello", ("Bye WOrld", 0), (_: Unit, _) => "Parsed", (_, _, _) => "Not Parsed", "Not Parsed")
-      checkFold(("Hello" ~ ("wtf" ~ "omg" | "wtfom")).!, ("Hellowtfom", 0),
-        (v: String, _) => s"Parsed: $v", (_, i, _) => s"Did not parse, failed at index $i", "Parsed: Hellowtfom")
-      checkFold("Hello" ~ ("wtf" ~ "omg" | "bbg"), ("Hellowtfom", 0), (_: Unit, _) => "Parsed",
-        (_, i, _) => s"Did not parse, failed at index $i", "Did not parse, failed at index 5")
     }
   }
 }

--- a/readme/ApiHighlights.scalatex
+++ b/readme/ApiHighlights.scalatex
@@ -68,10 +68,8 @@
 
     @sect{Parsing Results}
         @p
-            The two kinds of a @hl.scala{Parsed} result reflect the status of a parse:
-            a success (@hl.scala{Parsed.Success}) or a failure (@hl.scala{Parsed.Failure}).
-            First, both classes can be used in pattern matching to discriminate the parse status.
-            Second, they allow to extract the most commonly-used values.
+            The result of a parser comes in two flavors of @hl.scala{Parsed};
+            the first is a success (@hl.scala{Parsed.Success}) and the second is a failure (@hl.scala{Parsed.Failure}).
             @hl.scala{Parsed.Success} provides the parsed value -
             the value you are probably most interested in -
             and the index in the input string till where the parse was performed.
@@ -79,6 +77,19 @@
             Additionally, failure provides an @hl.scala{Parsed.Failure.extra} field that provides precise details about the failure:
             line and column numbers (via @hl.scala{extra.line} and @hl.scala{extra.col})
             and most importantly a complete stack trace of the involved parsers, which is accessible via @hl.scala{extra.traced}.
+
+        @p
+            The recommended method for dealing with @hl.scala{Parsed} is to use @hl.scala{fold} which accepts two callbacks.
+            The first callback deals with a failed parse attempt and has a type signature of @hl.scala{(Parser[_], Int, Failure.Extra) => X}.
+            Each input parameter corresponds to what is available in @hl.scala{Parsed.Failure}.
+            The second callback deals with a successful parsing and has type signature @hl.scala{(T, Int) => X} where @hl.scala{T} is the parsed result
+            and the @hl.scala{Int} is the index of the string where the parsing was performed.
+
+        @hl.ref(tests/"ExampleTests.scala", start = "sealed trait AndOr", end = "}")
+
+        @p
+            It is also possible to pattern match over @hl.scala{Parsed}, however, you may experience spurious warnings related to @a("SI-4440", href:="https://issues.scala-lang.org/browse/SI-4440").
+            In order to prevent these warnings @hl.scala{import fastparse.core.Result} in versions 0.2.x and @hl.scala{import fastparse.core.Parsed} in higher versions than 0.2.x.
 
         @p
             An overview of @hl.scala{Parsed}:


### PR DESCRIPTION
This should mostly resolve #34 as users would not have to pattern match on a the Parsed result type