### PR TITLE
Another pass of code/docs polish work for byte-parser API

### DIFF
--- a/classparse/shared/src/main/scala/classparse/ClassAttributes.scala
+++ b/classparse/shared/src/main/scala/classparse/ClassAttributes.scala
@@ -1,7 +1,7 @@
 package classparse
 
 import fastparse.byte._
-
+import BE._
 object ClassAttributes {
   import ClassParse.Info._
   import ClassParse.BasicElems._
@@ -55,7 +55,7 @@ object ClassAttributes {
 
   case class BootstrapMethodsAttribute(bootstrapMethods: Seq[BootstrapMethod]) extends Attribute
 
-  import fastparse.ByteUtils.BE._
+
 
   val constantValue = P( UInt16 ).map(idx => (classInfo: ClassFileInfo) =>
     ConstantValueAttribute(

--- a/classparse/shared/src/main/scala/classparse/ClassParse.scala
+++ b/classparse/shared/src/main/scala/classparse/ClassParse.scala
@@ -1,7 +1,7 @@
 package classparse
 
 import fastparse.byte._
-
+import BE._
 import scala.collection.mutable.ArrayBuffer
 // https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7
 
@@ -331,7 +331,7 @@ object ClassParse {
 
   import Info._
   import BasicElems._
-  import fastparse.ByteUtils.BE._
+
 
   val constantClassInfo = {
     val name_index = UInt16

--- a/classparse/shared/src/main/scala/classparse/CodeParser.scala
+++ b/classparse/shared/src/main/scala/classparse/CodeParser.scala
@@ -1,7 +1,7 @@
 package classparse
 
 import fastparse.byte._
-
+import BE._
 object CodeParser {
   sealed abstract class OpCode
 
@@ -243,7 +243,7 @@ object CodeParser {
 
   case object Wide extends OpCode // correct behavior for this command hasn't been implemented yet
 
-  import fastparse.ByteUtils.BE._
+
 
   val opCodeParsers = {
 

--- a/classparse/shared/src/test/scala/classparse/ClassTests.scala
+++ b/classparse/shared/src/test/scala/classparse/ClassTests.scala
@@ -19,7 +19,7 @@ object ClassTests extends TestSuite {
 
     'basic {
       'book {
-        val classFile = strToBytes("CA FE BA BE " +
+        val classFile = hexBytes("CA FE BA BE " +
           "00 00 00 34 00 1D 0A 00 05 00 18 09 00 04 00 19 09 00 04 00 1A 07 00 " +
           "1B 07 00 1C 01 00 05 74 69 74 6C 65 01 00 12 4C 6A 61 76 61 2F 6C 61 " +
           "6E 67 2F 53 74 72 69 6E 67 3B 01 00 07 70 75 62 59 65 61 72 01 00 01 " +
@@ -98,7 +98,7 @@ object ClassTests extends TestSuite {
                 CodeAttribute(1, 1,
                   ArrayBuffer(ALoad0, InvokeSpecial(1), Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 01 00 00 00 01")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 01")))
                 )
               )
             ),
@@ -109,7 +109,7 @@ object ClassTests extends TestSuite {
                 CodeAttribute(1, 1,
                   ArrayBuffer(ALoad0, GetField(2), AReturn),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 01 00 00 00 06")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 06")))
                 )
               )
             ),
@@ -120,7 +120,7 @@ object ClassTests extends TestSuite {
                 CodeAttribute(1, 1,
                   ArrayBuffer(ALoad0, GetField(3), IReturn),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 01 00 00 00 0A")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 0A")))
                 )
               )
             ),
@@ -131,7 +131,7 @@ object ClassTests extends TestSuite {
                 CodeAttribute(2, 2,
                   ArrayBuffer(ALoad0, ALoad1, PutField(2), Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 02 00 00 00 0E 00 05 00 0F")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 02 00 00 00 0E 00 05 00 0F")))
                 )
               )
             ),
@@ -142,7 +142,7 @@ object ClassTests extends TestSuite {
                 CodeAttribute(2, 2,
                   ArrayBuffer(ALoad0, ILoad1, PutField(3), Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 02 00 00 00 12 00 05 00 13")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 02 00 00 00 12 00 05 00 13")))
                 )
               )
             )
@@ -166,7 +166,7 @@ object ClassTests extends TestSuite {
       }
 
       'book2 {
-        val classFile = strToBytes("CA FE BA BE " +
+        val classFile = hexBytes("CA FE BA BE " +
           "00 00 00 34 00 4D 0A 00 12 00 34 09 00 11 00 35 09 00 11 00 36 09 " +
           "00 11 00 37 09 00 11 00 38 08 00 39 08 00 3A 08 00 3B 08 00 3C 07 " +
           "00 3D 0A 00 0A 00 34 0A 00 0A 00 3E 08 00 3F 0A 00 40 00 41 0A 00 " +
@@ -354,7 +354,7 @@ object ClassTests extends TestSuite {
                     InvokeSpecial(1),
                     Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 01 00 00 00 01")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 01")))
                 )
               )
             ),
@@ -369,7 +369,7 @@ object ClassTests extends TestSuite {
                     GetField(2),
                     AReturn),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 01 00 00 00 0a")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 0a")))
                 )
               )
             ),
@@ -384,7 +384,7 @@ object ClassTests extends TestSuite {
                     GetField(3),
                     IReturn),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 01 00 00 00 0e")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 0e")))
                 )
               )
             ),
@@ -399,7 +399,7 @@ object ClassTests extends TestSuite {
                     GetField(4),
                     AReturn),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 01 00 00 00 12")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 12")))
                 )
               )
             ),
@@ -414,7 +414,7 @@ object ClassTests extends TestSuite {
                     GetField(5),
                     IReturn),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 01 00 00 00 16")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 16")))
                 )
               )
             ),
@@ -430,7 +430,7 @@ object ClassTests extends TestSuite {
                     PutField(2),
                     Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 02 00 00 00 1a 00 05 00 1b")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 02 00 00 00 1a 00 05 00 1b")))
                 )
               )
             ),
@@ -446,7 +446,7 @@ object ClassTests extends TestSuite {
                     PutField(3),
                     Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 02 00 00 00 1e 00 05 00 1f")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 02 00 00 00 1e 00 05 00 1f")))
                 )
               )
             ),
@@ -462,7 +462,7 @@ object ClassTests extends TestSuite {
                     PutField(4),
                     Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 02 00 00 00 22 00 05 00 23")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 02 00 00 00 22 00 05 00 23")))
                 )
               )
             ),
@@ -478,7 +478,7 @@ object ClassTests extends TestSuite {
                     PutField(5),
                     Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", strToBytes("00 02 00 00 00 26 00 05 00 27")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 02 00 00 00 26 00 05 00 27")))
                 )
               )
             ),
@@ -531,11 +531,11 @@ object ClassTests extends TestSuite {
                   ArrayBuffer(
                     BasicAttribute(
                       "LineNumberTable",
-                      strToBytes("00 06 00 00 00 2c 00 20 00 2d 00 26 00 2e 00 2c 00 2f 00 32 00 30 00 35 00 32")
+                      hexBytes("00 06 00 00 00 2c 00 20 00 2d 00 26 00 2e 00 2c 00 2f 00 32 00 30 00 35 00 32")
                     ),
                     BasicAttribute(
                       "StackMapTable",
-                      strToBytes("00 05 20 05 05 05 fc 00 02 07 00 31")
+                      hexBytes("00 05 20 05 05 05 fc 00 02 07 00 31")
                     )
                   )
                 )
@@ -573,7 +573,7 @@ object ClassTests extends TestSuite {
       }
 
       'attributes {
-        val classFile = strToBytes("CA FE BA BE " +
+        val classFile = hexBytes("CA FE BA BE " +
           "00 00 00 34 00 27 0A 00 08 00 1E 07 00 1F 0A 00 02 00 20 07 00 21 " +
           "09 00 02 00 22 07 00 23 0A 00 06 00 1E 07 00 24 01 00 0A 49 6E 6E " +
           "65 72 43 6C 61 73 73 01 00 0C 49 6E 6E 65 72 43 6C 61 73 73 65 73 " +
@@ -643,13 +643,13 @@ object ClassTests extends TestSuite {
                   AThrow),
                 ArrayBuffer(),
                 ArrayBuffer(
-                  BasicAttribute("LineNumberTable", strToBytes("00 03 00 00 00 0c 00 09 00 0d 00 0f 00 0e"))
+                  BasicAttribute("LineNumberTable", hexBytes("00 03 00 00 00 0c 00 09 00 0d 00 0f 00 0e"))
                 )
               ),
               ExceptionsAttribute(ArrayBuffer(Class("java/io/IOException"))),
               DeprecatedAttribute,
               SignatureAttribute("()TT;"),
-              BasicAttribute("RuntimeVisibleAnnotations", strToBytes("00 01 00 1a 00 00"))
+              BasicAttribute("RuntimeVisibleAnnotations", hexBytes("00 01 00 1a 00 00"))
             )
           )
         )

--- a/fastparse/shared/src/test/scala/fastparse/ByteTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ByteTests.scala
@@ -28,44 +28,44 @@ object ByteTests extends TestSuite {
 
         val Parsed.Success(_, 2) = ab.parse(BS(1, 2)) // BS(1, 2) == Array[Byte](1, 2)
 
-        val Parsed.Failure(parser, 1, _) = ab.parse(strToBytes("01 01")) // or BS(1, 1)
+        val Parsed.Failure(parser, 1, _) = ab.parse(hexBytes("01 01")) // or BS(1, 1)
         assert(parser == (BS(2): P0))
       }
 
       'repeat {
         import fastparse.byte._
         val ab = P(BS(1).rep ~ BS(2))
-        val Parsed.Success(_, 8) = ab.parse(strToBytes("01 01 01 01 01 01 01 02"))
-        val Parsed.Success(_, 4) = ab.parse(strToBytes("01 01 01 02"))
+        val Parsed.Success(_, 8) = ab.parse(hexBytes("01 01 01 01 01 01 01 02"))
+        val Parsed.Success(_, 4) = ab.parse(hexBytes("01 01 01 02"))
 
         val abc = P(BS(1).rep(sep = BS(2)) ~ BS(3))
-        val Parsed.Success(_, 8) = abc.parse(strToBytes("01 02 01 02 01 02 01 03"))
-        val Parsed.Failure(parser, 3, _) = abc.parse(strToBytes("01 02 01 01 02 01 03"))
+        val Parsed.Success(_, 8) = abc.parse(hexBytes("01 02 01 02 01 02 01 03"))
+        val Parsed.Failure(parser, 3, _) = abc.parse(hexBytes("01 02 01 01 02 01 03"))
 
         val ab4 = P(BS(1).rep(min = 2, max = 4, sep = BS(2)))
-        val Parsed.Success(_, 7) = ab4.parse(strToBytes("01 02 01 02 01 02 01 02 01 02 01 02 01 02 01 02"))
+        val Parsed.Success(_, 7) = ab4.parse(hexBytes("01 02 01 02 01 02 01 02 01 02 01 02 01 02 01 02"))
 
         val ab4c = P(BS(1).rep(min = 2, max = 4, sep = BS(2)) ~ BS(3))
-        val Parsed.Failure(_, 1, _) = ab4c.parse(strToBytes("01 03"))
-        val Parsed.Success(_, 4) = ab4c.parse(strToBytes("01 02 01 03"))
-        val Parsed.Success(_, 8) = ab4c.parse(strToBytes("01 02 01 02 01 02 01 03"))
-        val Parsed.Failure(_, 7, _) = ab4c.parse(strToBytes("01 02 01 02 01 02 01 02 01 03"))
+        val Parsed.Failure(_, 1, _) = ab4c.parse(hexBytes("01 03"))
+        val Parsed.Success(_, 4) = ab4c.parse(hexBytes("01 02 01 03"))
+        val Parsed.Success(_, 8) = ab4c.parse(hexBytes("01 02 01 02 01 02 01 03"))
+        val Parsed.Failure(_, 7, _) = ab4c.parse(hexBytes("01 02 01 02 01 02 01 02 01 03"))
       }
 
       'option {
         import fastparse.byte._
         val option = P(BS(3).? ~ BS(1).rep(sep = BS(2)).! ~ End)
 
-        val Parsed.Success(Array(1, 2, 1), 3) = option.parse(strToBytes("01 02 01"))
-        val Parsed.Success(Array(1, 2, 1), 3) = option.parse(strToBytes("01 02 01"))
+        val Parsed.Success(Array(1, 2, 1), 3) = option.parse(hexBytes("01 02 01"))
+        val Parsed.Success(Array(1, 2, 1), 3) = option.parse(hexBytes("01 02 01"))
       }
 
       'either {
         import fastparse.byte._
         val either = P(BS(1).rep ~ (BS(2) | BS(3) | BS(4)) ~ End)
 
-        val Parsed.Success(_, 6) = either.parse(strToBytes("01 01 01 01 01 02"))
-        val Parsed.Failure(parser, 5, _) = either.parse(strToBytes("01 01 01 01 01 05"))
+        val Parsed.Success(_, 6) = either.parse(hexBytes("01 01 01 01 01 02"))
+        val Parsed.Failure(parser, 5, _) = either.parse(hexBytes("01 01 01 01 01 05"))
         assert(parser == (BS(2) | BS(3) | BS(4)))
       }
 
@@ -75,86 +75,91 @@ object ByteTests extends TestSuite {
         val noEnd = P(BS(1).rep ~ BS(2))
         val withEnd = P(BS(1).rep ~ BS(2) ~ End)
 
-        val Parsed.Success(_, 4) = noEnd.parse(strToBytes("01 01 01 02 01"))
-        val Parsed.Failure(End, 4, _) = withEnd.parse(strToBytes("01 01 01 02 01"))
+        val Parsed.Success(_, 4) = noEnd.parse(hexBytes("01 01 01 02 01"))
+        val Parsed.Failure(End, 4, _) = withEnd.parse(hexBytes("01 01 01 02 01"))
 
       }
       'start {
         import fastparse.byte._
         val ab = P(((BS(1) | Start) ~ BS(2)).rep ~ End).!
 
-        val Parsed.Success(Array(1, 2, 1, 2), 4) = ab.parse(strToBytes("01 02 01 02"))
-        val Parsed.Success(Array(2, 1, 2, 1, 2), 5) = ab.parse(strToBytes("02 01 02 01 02"))
+        val Parsed.Success(Array(1, 2, 1, 2), 4) = ab.parse(hexBytes("01 02 01 02"))
+        val Parsed.Success(Array(2, 1, 2, 1, 2), 5) = ab.parse(hexBytes("02 01 02 01 02"))
 
-        val Parsed.Failure(parser, 2, _) = ab.parse(strToBytes("01 02 02"))
+        val Parsed.Failure(parser, 2, _) = ab.parse(hexBytes("01 02 02"))
 
       }
 
       'passfail {
         import fastparse.byte._
-        val Parsed.Success((), 0) = Pass.parse(strToBytes("04 08 15 16 23 42"))
-        val Parsed.Failure(Fail, 0, _) = Fail.parse(strToBytes("04 08 15 16 23 42"))
+        val Parsed.Success((), 0) = Pass.parse(hexBytes("04 08 15 16 23 42"))
+        val Parsed.Failure(Fail, 0, _) = Fail.parse(hexBytes("04 08 15 16 23 42"))
       }
 
       'index {
         import fastparse.byte._
         val finder = P(BS(1, 1, 1).rep ~ Index ~ BS(2, 2, 2) ~ BS(3, 3, 3).rep)
 
-        val Parsed.Success(9, _) = finder.parse(strToBytes(" 01 01 01  01 01 01  01 01 01  02 02 02  03 03 03"))
+        val Parsed.Success(9, _) = finder.parse(hexBytes(" 01 01 01  01 01 01  01 01 01  02 02 02  03 03 03"))
       }
 
       'capturing {
         import fastparse.byte._
         val capture1 = P(BS(1).rep.! ~ BS(2) ~ End)
 
-        val Parsed.Success(Array(1, 1, 1), 4) = capture1.parse(strToBytes("01 01 01 02"))
+        val Parsed.Success(Array(1, 1, 1), 4) = capture1.parse(hexBytes("01 01 01 02"))
 
         val capture2 = P(BS(1).rep.! ~ BS(2).! ~ End)
 
-        val Parsed.Success((Array(1, 1, 1), Array(2)), 4) = capture2.parse(strToBytes("01 01 01 02"))
+        val Parsed.Success((Array(1, 1, 1), Array(2)), 4) = capture2.parse(hexBytes("01 01 01 02"))
 
         val capture3 = P(BS(1).rep.! ~ BS(2).! ~ BS(3).! ~ End)
 
-        val Parsed.Success((Array(1, 1, 1), Array(2), Array(3)), 5) = capture3.parse(strToBytes("01 01 01 02 03"))
+        val Parsed.Success((Array(1, 1, 1), Array(2), Array(3)), 5) = capture3.parse(hexBytes("01 01 01 02 03"))
 
         val captureRep = P(BS(1).!.rep ~ BS(2) ~ End)
 
-        val Parsed.Success(Seq(Array(1), Array(1), Array(1)), 4) = captureRep.parse(strToBytes("01 01 01 02"))
+        val Parsed.Success(Seq(Array(1), Array(1), Array(1)), 4) = captureRep.parse(hexBytes("01 01 01 02"))
 
         val captureOpt = P(BS(1).rep ~ BS(2).!.? ~ End)
 
-        val Parsed.Success(Some(Array(2)), 4) = captureOpt.parse(strToBytes("01 01 01 02"))
+        val Parsed.Success(Some(Array(2)), 4) = captureOpt.parse(hexBytes("01 01 01 02"))
       }
       'unapply {
         import fastparse.byte._
         val capture1 = P(BS(1).rep.! ~ BS(2) ~ End)
 
-        val capture1(Array(1, 1, 1)) = strToBytes("01 01 01 02")
+        val capture1(Array(1, 1, 1)) = hexBytes("01 01 01 02")
 
         val capture2 = P(BS(1).rep.! ~ BS(2).! ~ End)
 
-        val capture2(Array(1, 1, 1), Array(2)) = strToBytes("01 01 01 02")
+        val capture2(Array(1, 1, 1), Array(2)) = hexBytes("01 01 01 02")
 
         val capture3 = P(BS(1).rep.! ~ BS(2).! ~ BS(3).! ~ End)
 
-        val capture3(Array(1, 1, 1), Array(2), Array(3)) = strToBytes("01 01 01 02 03")
+        val capture3(Array(1, 1, 1), Array(2), Array(3)) = hexBytes("01 01 01 02 03")
 
         val captureRep = P(BS(1).!.rep ~ BS(2) ~ End)
 
-        val captureRep(Seq(Array(1), Array(1), Array(1))) = strToBytes("01 01 01 02")
+        val captureRep(Seq(Array(1), Array(1), Array(1))) = hexBytes("01 01 01 02")
 
         val captureOpt = P(BS(1).rep ~ BS(2).!.? ~ End)
 
-        val captureOpt(Some(Array(2))) = strToBytes("01 01 01 02")
+        val captureOpt(Some(Array(2))) = hexBytes("01 01 01 02")
       }
-      'anychar {
+      'anybyte {
         import fastparse.byte._
         val ab = P(BS(1) ~ AnyByte.! ~ BS(1))
 
-        val Parsed.Success(Array(0x42), 3) = ab.parse(strToBytes("01 42 01"))
+        val Parsed.Success(Array(0x42), 3) = ab.parse(hexBytes("01 42 01"))
 
-        val Parsed.Failure(parser, 2, _) = ab.parse(strToBytes("01 42 43 01"))
-        assert(parser == (BS(1): P0))
+        val failure @ Parsed.Failure(parser, 2, _) = ab.parse(hexBytes("01 42 43 01"))
+
+        assert(
+          parser == (BS(1): P0),
+          failure.msg == """ "01":2 ..."43 01" """.trim
+        )
+
       }
 
 
@@ -162,16 +167,16 @@ object ByteTests extends TestSuite {
         import fastparse.byte._
         val keyword = P((BS(1, 2, 3) ~ &(BS(4))).!.rep)
 
-        val Parsed.Success(Seq(Array(1, 2, 3)), _) = keyword.parse(strToBytes("01 02 03 04"))
-        val Parsed.Success(Seq(), __) = keyword.parse(strToBytes("01 02 03 05"))
+        val Parsed.Success(Seq(Array(1, 2, 3)), _) = keyword.parse(hexBytes("01 02 03 04"))
+        val Parsed.Success(Seq(), __) = keyword.parse(hexBytes("01 02 03 05"))
       }
       'neglookahead {
         import fastparse.byte._
         val keyword = P(BS(1, 2, 3) ~ !BS(0) ~ AnyByte ~ BS(5, 6, 7)).!
 
-        val Parsed.Success(Array(1, 2, 3, 0x42, 5, 6, 7), _) = keyword.parse(strToBytes("01 02 03 42 05 06 07"))
+        val Parsed.Success(Array(1, 2, 3, 0x42, 5, 6, 7), _) = keyword.parse(hexBytes("01 02 03 42 05 06 07"))
 
-        val Parsed.Failure(parser, 4, _) = keyword.parse(strToBytes("01 02 03 00 05 06 07"))
+        val Parsed.Failure(parser, 4, _) = keyword.parse(hexBytes("01 02 03 00 05 06 07"))
         assert(parser == !BS(0))
       }
       'map {
@@ -179,8 +184,8 @@ object ByteTests extends TestSuite {
         val binary = P((BS(0) | BS(1)).rep.!)
         val binaryNum = P(binary.map(_.sum))
 
-        val Parsed.Success(Array(1, 1, 0, 0), _) = binary.parse(strToBytes("01 01 00 00"))
-        val Parsed.Success(2, _) = binaryNum.parse(strToBytes("01 01 00 00"))
+        val Parsed.Success(Array(1, 1, 0, 0), _) = binary.parse(hexBytes("01 01 00 00"))
+        val Parsed.Success(2, _) = binaryNum.parse(hexBytes("01 01 00 00"))
       }
     }
 
@@ -213,7 +218,7 @@ object ByteTests extends TestSuite {
         }
 
         check(
-          Foo.ints.parse(strToBytes("ff 00 00 00 00")),
+          Foo.ints.parse(hexBytes("ff 00 00 00 00")),
           """Failure((int | longInt):0 ..."ff 00 00 00 00")"""
         )
 
@@ -227,7 +232,7 @@ object ByteTests extends TestSuite {
           val ints = P( (int | longInt).rep(1) )
         }
         check(
-          Foo.ints.parse(strToBytes("ff 00 00 00 00")),
+          Foo.ints.parse(hexBytes("ff 00 00 00 00")),
           """Failure(AnyElem:5 ..."")"""
         )
       }
@@ -243,7 +248,7 @@ object ByteTests extends TestSuite {
         }
 
 
-        Foo.ints.parse(strToBytes("ff 00 00 00 00"))
+        Foo.ints.parse(hexBytes("ff 00 00 00 00"))
 
         val expected = """
             +ints:0
@@ -260,6 +265,40 @@ object ByteTests extends TestSuite {
         assert(capturedString == expectedString)
       }
     }
+    'example{
+      'udp{
+        import fastparse.byte._
+        case class UdpPacket(sourcePort: Int, destPort: Int, checkSum: Int, data: Array[Byte])
 
+        // BE.UInt16 stands for big-endian unsigned-16-bit-integer parsers
+        val udpHeader = P( BE.UInt16 ~ BE.UInt16 ~ BE.UInt16 ~ BE.UInt16 )
+
+        val udpParser = P(
+          for{
+            (sourcePort, destPort, length, checkSum) <- udpHeader
+            data <- AnyByte.rep(exactly=length - 8).!
+          } yield UdpPacket(sourcePort, destPort, checkSum, data)
+        )
+
+        val bytes = hexBytes(
+          "04 89 00 35 00 2C AB B4 00 01 01 00 00 01 00 00 " +
+          "00 00 00 00 04 70 6F 70 64 02 69 78 06 6E 65 74 " +
+          "63 6F 6D 03 63 6F 6D 00 00 01 00 01"
+        )
+
+        val Parsed.Success(packet, _) = udpParser.parse(bytes)
+        assert(
+          packet.sourcePort == 1161,
+          packet.destPort == 53,
+          packet.checkSum == 43956,
+          packet.data.length == 36,
+          packet.data.toSeq == hexBytes(
+            "00 01 01 00 00 01 00 00 00 00 00 00 04 70 6F 70 " +
+            "64 02 69 78 06 6E 65 74 63 6F 6D 03 63 6F 6D 00 " +
+            "00 01 00 01"
+          ).toSeq
+        )
+      }
+    }
   }
 }

--- a/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
@@ -188,6 +188,24 @@ object ExampleTests extends TestSuite{
           failure.extra.traced.trace == """xml:1:1 / rightTag:1:8 / "abcde":1:10 ..."edcba>""""
         )
       }
+      'flatMapFor{
+        val leftTag = P( "<" ~ (!">" ~ AnyChar).rep(1).! ~ ">" )
+        def rightTag(s: String) = P( "</" ~ s.! ~ ">" )
+        val xml = P(
+          for{
+            s <- leftTag
+            right <- rightTag(s)
+          } yield right
+        )
+
+        val Parsed.Success("a", _) = xml.parse("<a></a>")
+        val Parsed.Success("abcde", _) = xml.parse("<abcde></abcde>")
+
+        val failure = xml.parse("<abcde></edcba>").asInstanceOf[Parsed.Failure]
+        assert(
+          failure.extra.traced.trace == """xml:1:1 / rightTag:1:8 / "abcde":1:10 ..."edcba>""""
+        )
+      }
       'filter{
         val digits = P(CharIn('0' to '9').rep(1).!).map(_.toInt)
         val even = digits.filter(_ % 2 == 0)

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -4,5 +4,5 @@ addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.5")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.9")
 
-
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M14")
 

--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -190,6 +190,14 @@
 
                 @p
                     Note that the function given to @hl.scala{.flatMap} is evaluated every time this parser is tried. You should be conscious of the cost of re-creating the resultant parser every time, since FastParse parsers are somewhat expensive to initialize despite being fast per-run. If possible, store the parsers somewhere before-hand or memo-ize/cache them to avoid initializing them wastefully.
+                @p
+                    As is normal in Scala, you can replace a @hl.scala{.flatMap} call with a @hl.scala{for}-comprehension, as below:
+
+                @hl.ref(tests/"ExampleTests.scala", Seq("'flatMapFor", ""))
+
+                @p
+                    Which is equivalent and behaves exactly the same.
+
             @sect{Filter}
                 @hl.ref(tests/"ExampleTests.scala", Seq("'filter", ""))
 
@@ -427,7 +435,7 @@
                 cost, as you can see below...
 
 
-        @sect{Streaming Parsing Performane}
+        @sect{Streaming Parsing Performance}
             @p
                 This next benchmark measures the effect of streaming parsing on
                 runtime performance, using two different chunk-sizes, compared
@@ -639,6 +647,47 @@
 
             @div(id := "jsondiv")
             @script(raw("""demo.DemoMain().json(document.getElementById("jsondiv"))"""))
+
+        @sect{ScalaParse}
+
+            @div(id := "scaladiv")
+            @script(raw("""demo.DemoMain().scalaparser(document.getElementById("scaladiv"))"""))
+
+            @p
+                ScalaParse is a parser for the entire Scala programming language, written using FastParse. This is notable for a few reasons:
+
+            @ul
+                @li
+                    ScalaParse is about 700 lines of code, making it about 1/10th the size of the default parser in @hl.scala{tools.nsc.Global}
+                @li
+                    ScalaParse runs about @sect.ref("Performance", "1/8th the speed") of of the default parser in @hl.scala{tools.nsc.Global}
+                @li
+                    ScalaParse has excellent error reporting due to proper use of @sect.ref{Cuts}, without any code explicitly dedicated to error reporting
+            @p
+                ScalaParse does not currently generate an AST. As you can see, the parse result above is listed as @hl.scala{undefined}. However, that does not make it useless! Even without generating an AST, ScalaParse can be used to:
+
+            @ul
+                @li
+                    Check for errors! ScalaParse provides excellent error reporting on parses, equal or better than that provided by the tools.nsc.Global parser, entirely for free.
+                @li
+                    Prototype extensions to the Scala grammar! Unlike the default tools.nsc.Global parser, ScalaParse makes it trivial to add new rules at various sections of the grammar.
+                @li
+                    Manipulate Scala code sections! It's trivial to wrap various rules in ScalaParse in an @sect.ref{Capture} and use it to pull out the relevant bits of a Scala file for you to use.
+
+
+            @sect{Using ScalaParse}
+                @p
+                To begin using ScalaParse, add
+
+                @hl.scala
+                    "com.lihaoyi" %% "scalaparse" % "@fastparse.Constants.version"
+
+                @p
+                    To your SBT configuration. To use with Scala.js, you'll need
+
+                @hl.scala
+                    "com.lihaoyi" %%% "scalaparse" % "@fastparse.Constants.version"
+
         @sect{PythonParse}
             @p
                 There is now an @a("example Python parser", href:="https://github.com/lihaoyi/fastparse/tree/master/pythonparse/shared/src/main/scala/pythonparse") available under a subproject in the repo. This is a good example of a real-world parser: parsing knotty syntax (including indentation-delimited blocks!), building an AST, and with heavy unit tests.
@@ -1003,6 +1052,23 @@
             @p
                 These operations are not cheap: the bitsets easily take a few KB of memory each, and involve 65k iterations to fill them in. However, since @hl.scala{Parser}s are immutable, this one-time-cost goes from "ridiculous" to "acceptable". All these internal optimizations are completely opaque to the user, who (apart from performance) never need to think about them.
 
+        @sect{Parsing Only}
+            @p
+                Fastparse, unlike libraries like @lnk("Scodec", "https://github.com/scodec/scodec")
+                or Python's @lnk("Construct", "https://pypi.python.org/pypi/construct"),
+                only allows you to define how to parse data from serialized
+                text/bytes into structured data, and not the other way around.
+
+            @p
+                It is probably possible to write a wrapper on top of FastParse
+                that will allow two-directional serialization, but such a thing
+                does not exist right now in the FastParse codebase, and would
+                likely be pretty difficult to design and implement. If you need
+                such a thing you could try writing your own wrapper and (if it
+                works out well) contributing it back to FastParse, or otherwise
+                just use something else like
+                @lnk("Scodec", "https://github.com/scodec/scodec")
+                which has this capability build in.
 
         @sect{Abstraction}
             @p
@@ -1093,49 +1159,30 @@
         (or @hl.scala{Iterator[Array[Byte]]}s) into structured data
 
     @p
-        This first example demonstrates a basic byte-parser, which parses the
-        two bytes @code{1} and @code{2}:
+        This is an example @lnk("UDP Datagram", "https://en.wikipedia.org/wiki/User_Datagram_Protocol")
+        packet-parser implemented using FastParse's byte-parsing api:
 
-    @hl.ref(tests/"ByteTests.scala", Seq("'sequence", ""))
+    @hl.ref(tests/"ByteTests.scala", Seq("'udp", ""), "val bytes =")
 
     @p
         As you can see it has the same underlying structure as previous
-        @sect.ref{Basic} string-parsers, but with some differences:
+        @sect.ref{Basic} string-parsers: it uses @code{~} to @sect.ref{Sequence}
+        parsers, @hl.scala{for}-comprehensions to @sect.ref{FlatMap} them,
+        @hl.scala{!} to @sect.ref{Capture} them, etc..
 
-    @sect{Equivalent Byte Parsers}
-        @p
-            Byte Parsers doesn't bring anything new to the basic set of parsers.
-            @sect.ref{Optional}, @sect.ref{Repeat}, @sect.ref{Capture} and etc.
-            are still here with the same logic, but there are some new names for
-            @hl.scala{Byte} versions of some of them:
+    @p
+        Here is how we use it:
 
-        @ul
-            @li
-                @hl.scala{BS} or @hl.scala{ByteSeq} is an alias for
-                @hl.scala{Array[Byte]}, and is used when defining byte parsers
-                as a replacement for literal strings.
-            @li
-                @sect.ref{AnyChar} becomes @hl.scala{AnyByte}
-             @li
-                @sect.ref{CharPred} becomes @hl.scala{BytePred}
-             @li
-                @sect.ref{CharIn} becomes @hl.scala{ByteIn}
-             @li
-                @sect.ref{CharsWhile} becomes @hl.scala{BytesWhile}
-             @li
-                @p
-                    @hl.scala{StringIn} becomes @hl.scala{SeqIn}
-                @i
-                    It isn't a simple replacement of substrings, and the reason for
-                    this is described in @sect.ref{Abstraction}.
+    @hl.ref(tests/"ByteTests.scala", Seq("'udp", "", "val bytes ="))
 
-         @p
-            For instance, the basic parser with @hl.scala{AnyByte}, used with a
-            @sect.ref{Capture} @code{.!}, works and looks the same as @sect.ref{AnyChar}
-            did, except now it captures a @code{BS} (or @code{Array[Byte]})
-            rather than a @code{String}
+    @p
+        About the same as what you would expect, if you had used FastParse
+        to parse textual Strings.
 
-         @hl.ref(tests/"ByteTests.scala", Seq("'anychar", ""))
+    @p
+        While FastParse's byte-parsing API is similar to the string-parsing
+        API, there are some new primitives that are specific to byte parsers,
+        and some existing primitives that are named slightly differently.
 
     @sect{Byte-Specific Parsers}
         @p
@@ -1162,11 +1209,57 @@
             so you have to pick which one you want to use. You can also @hl.scala{import LE._}
             or @hl.scala{import BE._} if the endian-ness is the same throughout
             your parser, and then use @code{Int16}/@code{Int32}/@code{Int64} directly.
+            Typically, big-endian formats are common in networking applications
+            (e.g. UDP packets) while little-endian formats are common in operating
+            systems and micro-processors.
+
+    @sect{Equivalent Byte Parsers}
+        @p
+            Apart from the byte-specific parsers mentioned above, Fastparse's
+            byte-parsing API has many of the
+
+        @ul
+            @li
+                @hl.scala{BS} or @hl.scala{ByteSeq} is an alias for
+                @hl.scala{Array[Byte]}, and is used for parsing hard-coded
+                sequences of bytes. This is equivalent to the most basic
+                @sect.ref("Basic", "literal string parsers") in Fastparse's
+                string-parsing API
+            @li
+                @sect.ref{AnyChar} becomes @hl.scala{AnyByte}
+            @li
+                @sect.ref{CharPred} becomes @hl.scala{BytePred}
+            @li
+                @sect.ref{CharIn} becomes @hl.scala{ByteIn}
+            @li
+                @sect.ref{CharsWhile} becomes @hl.scala{BytesWhile}
+            @li
+                @hl.scala{StringIn} becomes @hl.scala{SeqIn}
+
+        @p
+            For example, here is a small example using @hl.scala{BS}
+            primitives and @hl.scala{AnyByte}
+
+        @hl.ref(tests/"ByteTests.scala", Seq("'anybyte", ""))
+
+    @sect{Byte Parser Similarities}
+
+        @p
+            Apart from the changes listed above, FastParse's byte-parsing API works about
+            same as it's string-parsing API. @sect.ref{Sequence}, @sect.ref{Repeat},
+            @sect.ref{Optional}, @sect.ref{Either}, @sect.ref{Capture}, @sect.ref{Map},
+            @sect.ref{FlatMap}, @sect.ref{Filter} and many other operators all work
+            the same when parsing bytes as they do when parsing strings.
+
+            The process of @sect.ref{Debugging Parsers}, @sect.ref{Using Cuts}
+            or @sect.ref{Using Log} to figure out what is going on, is all identical
+            between FastParse's byte-parsing and string-parsing APIs.
+
 
     @sect{Example Byte Parsers}
         @sect{BmpParser}
             @p
-                @hl.scala{BmpParser} is a good first example of byte parser:
+                @hl.scala{BmpParser} is a good example of a slightly more complex byte parser:
                 a parser for @lnk("Bitmap image files", "https://en.wikipedia.org/wiki/BMP_file_format").
                 It's not small, but structure is pretty simple. It does not
                 support the full breadth of the Bitmap format, but it supports
@@ -1226,10 +1319,12 @@
                         and the easiest and fastest method to parse them is to write @hl.scala{.rep(exactly=...)}.
                     @li
                         @b
-                            The same extensive usage of @hl.scala{.flatMap}.@br
-                        @hl.scala{flatMap} allows to retrieve data from one parser and pass it to the next.
-                        The most popular and primitive example is dynamic-sized array with length written at the beginning.
-                        Similar algorithm is used in the @hl.scala{bmp} when header information is passed to the @hl.scala{bmpRow}
+                            The same extensive usage of @hl.scala{for}-comprehensions.@br
+                        @hl.scala{for}-comprehensions (equivalent to @hl.scala{flatMap})
+                        allow to retrieve data from one parser and pass it to the next.
+                        The most popular and primitive example is dynamic-sized array with
+                        length written at the beginning. Similar algorithm is used in the
+                        @hl.scala{bmp} when header information is passed to the @hl.scala{bmpRow}
                         that returns new parser for row in this particular bmp file.
 
         @sect{ClassParser}
@@ -1277,48 +1372,8 @@
                 demo, or you can download the sources and compile them yourself
                 with @code{javac} before uploading the generated class file.
 
-@sect{ScalaParse}
-
-    @div(id := "scaladiv")
-    @script(raw("""demo.DemoMain().scalaparser(document.getElementById("scaladiv"))"""))
-
-    @p
-        ScalaParse is a parser for the entire Scala programming language, written using FastParse. This is notable for a few reasons:
-
-    @ul
-        @li
-            ScalaParse is about 700 lines of code, making it about 1/10th the size of the default parser in @hl.scala{tools.nsc.Global}
-        @li
-            ScalaParse runs about @sect.ref("Performance", "1/8th the speed") of of the default parser in @hl.scala{tools.nsc.Global}
-        @li
-            ScalaParse has excellent error reporting due to proper use of @sect.ref{Cuts}, without any code explicitly dedicated to error reporting
-    @p
-        ScalaParse does not currently generate an AST. As you can see, the parse result above is listed as @hl.scala{undefined}. However, that does not make it useless! Even without generating an AST, ScalaParse can be used to:
-
-    @ul
-        @li
-            Check for errors! ScalaParse provides excellent error reporting on parses, equal or better than that provided by the tools.nsc.Global parser, entirely for free.
-        @li
-            Prototype extensions to the Scala grammar! Unlike the default tools.nsc.Global parser, ScalaParse makes it trivial to add new rules at various sections of the grammar.
-        @li
-            Manipulate Scala code sections! It's trivial to wrap various rules in ScalaParse in an @sect.ref{Capture} and use it to pull out the relevant bits of a Scala file for you to use.
-
-
-    @sect{Using ScalaParse}
-        @p
-        To begin using ScalaParse, add
-
-        @hl.scala
-            "com.lihaoyi" %% "scalaparse" % "@fastparse.Constants.version"
-
-        @p
-            To your SBT configuration. To use with Scala.js, you'll need
-
-        @hl.scala
-            "com.lihaoyi" %%% "scalaparse" % "@fastparse.Constants.version"
-
 @sect{Change Log}
-    @sect{0.4}
+    @sect{0.4.0}
         @ul
             @li
                 New @sect.ref{CssParse} in cssparse module, as an example CSS parser


### PR DESCRIPTION
- Rename `strToBytes` -> `hexBytes`, to make it clear what kind of st…ring it is

- `BytesParser` -> `HexBytesParser`

- Added forwarder values for `LE` and `BE` inside `fastparse.bytes` so you don't need to import them separately

- Converted a few `.flatMap`s to use `for`-comprehensions since I think those are nicer to read. Added some docs to mention that you can use both `for`-comprehensions and explicit `flatMap`s

- Added a new `fastparse.bytes` example: a UDP packet parser, which I made into the top-example for the`Byte Parsers` docs

- Moved `ScalaParse` doc under the `Example Parsers`, since top-level was getting a bit crowded

- Added a new documentation section under `Internals`, to mention how two-way round-trip parse -> re-serialization isn't supported by FastParse.

- Flipped the order of `Equivalent Byte Parsers` and `Byte-specific Parsers`, now that the primary example for byte parsers uses things like `BE.UInt16`

- Turn on Coursier as a SBT plugin to make ivy resolution faster

Review by @vovapolu 