### PR TITLE
Properly handle cuts in LHS of flatMap calls and Not/Lookahead/Filter

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
+++ b/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
@@ -215,6 +215,7 @@ trait Mutable[+T, ElemType]{
    * this success, which prevents backtracking.
    */
   def cut: Boolean
+  def cut_=(c: Boolean): Unit
 }
 object Mutable{
 

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
@@ -172,10 +172,10 @@ object Combinators {
    */
   case class Lookahead[ElemType, Repr](p: Parser[_, ElemType, Repr]) extends Parser[Unit, ElemType, Repr]{
     def parseRec(cfg: ParseCtx[ElemType, Repr], index: Int) = {
-      val oldFork = cfg.isFork
-      cfg.isFork = true
+      val oldNoCut = cfg.isNoCut
+      cfg.isNoCut = true
       val res = p.parseRec(cfg, index)
-      cfg.isFork = oldFork
+      cfg.isNoCut = oldNoCut
 
       res match{
         case s: Mutable.Success[_, ElemType] =>
@@ -194,7 +194,10 @@ object Combinators {
    */
   case class Not[ElemType, Repr](p: Parser[_, ElemType, Repr]) extends Parser[Unit, ElemType, Repr]{
     def parseRec(cfg: ParseCtx[ElemType, Repr], index: Int) = {
+      val oldNoCut = cfg.isNoCut
+      cfg.isNoCut = true
       val res0 = p.parseRec(cfg, index)
+      cfg.isNoCut = oldNoCut
       val res = res0 match{
         case s: Mutable.Success[_, ElemType] => fail(cfg.failure, s.index)
         case f: Mutable.Failure[ElemType] => success(cfg.success, (), index, Set.empty, false)

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Transformers.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Transformers.scala
@@ -27,7 +27,11 @@ object Transformers {
     def parseRec(cfg: ParseCtx[ElemType, Repr], index: Int) = {
       p1.parseRec(cfg, index) match{
         case f: Mutable.Failure[ElemType] => failMore(f, index, cfg.logDepth, cut = false)
-        case s: Mutable.Success[T, ElemType] => func(s.value).parseRec(cfg, s.index)
+        case s: Mutable.Success[T, ElemType] =>
+          val sCut = s.cut
+          val res = func(s.value).parseRec(cfg, s.index)
+          res.cut = sCut
+          res
       }
     }
   }

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Transformers.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Transformers.scala
@@ -43,7 +43,7 @@ object Transformers {
         case f: Mutable.Failure[ElemType] => failMore(f, index, cfg.logDepth, cut = false)
         case s: Mutable.Success[T, ElemType] =>
           if (predicate(s.value)) s
-          else fail(cfg.failure,index, s.traceParsers, cut = false)
+          else fail(cfg.failure, index, s.traceParsers, cut = s.cut)
       }
     }
 

--- a/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
@@ -104,8 +104,7 @@ object ParsingTests extends TestSuite{
         checkFail(("Hello" ~/ "Bye").?, ("HelloBoo", 0), 5)
       }
       'flatMap{
-        checkFail(("Hello" ~/ "Boo").flatMap(_ => Fail).?, ("HelloBoo", 0), 8)
-        checkFail((("Hello" ~/ "Boo").flatMap(_ => Pass) ~ Fail).?, ("HelloBoo", 0), 8)
+        checkFlatmap()
       }
       'filter{
         checkFail(("Hello" ~/ "Boo").filter(_ => false) | "", ("HelloBoo", 0), 0)
@@ -120,6 +119,12 @@ object ParsingTests extends TestSuite{
         check(&("Hello" ~/ "Boo") ~ "lol" | "", ("HelloBoo", 0), Success((), 0))
       }
     }
+  }
+  // Broken out of the TestSuite block to avoid problems in our 2.10.x
+  // build due to https://issues.scala-lang.org/browse/SI-7987
+  def checkFlatmap() = {
+    checkFail(("Hello" ~/ "Boo").flatMap(_ => Fail).?, ("HelloBoo", 0), 8)
+    checkFail((("Hello" ~/ "Boo").flatMap(_ => Pass) ~ Fail).?, ("HelloBoo", 0), 8)
   }
 }
 

--- a/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
@@ -107,6 +107,9 @@ object ParsingTests extends TestSuite{
         checkFail(("Hello" ~/ "Boo").flatMap(_ => Fail).?, ("HelloBoo", 0), 8)
         checkFail((("Hello" ~/ "Boo").flatMap(_ => Pass) ~ Fail).?, ("HelloBoo", 0), 8)
       }
+      'filter{
+        checkFail(("Hello" ~/ "Boo").filter(_ => false) | "", ("HelloBoo", 0), 0)
+      }
       'lookaheadNot{
         // ! disables cuts: since the whole point of it is to backtrack there
         // isn't any use case where a user would *want* the cuts to take effect

--- a/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
@@ -107,6 +107,15 @@ object ParsingTests extends TestSuite{
         checkFail(("Hello" ~/ "Boo").flatMap(_ => Fail).?, ("HelloBoo", 0), 8)
         checkFail((("Hello" ~/ "Boo").flatMap(_ => Pass) ~ Fail).?, ("HelloBoo", 0), 8)
       }
+      'lookaheadNot{
+        // ! disables cuts: since the whole point of it is to backtrack there
+        // isn't any use case where a user would *want* the cuts to take effect
+        check(!("Hello" ~/ "Bye"), ("HelloBoo", 0), Success((), 0))
+        // &() disables cuts: whether it succeeds or fails, the whole point
+        // of &() is to backtrack and re-parse things
+        check(&("Hello" ~/ "Bye") ~ "lol" | "", ("HelloBoo", 0), Success((), 0))
+        check(&("Hello" ~/ "Boo") ~ "lol" | "", ("HelloBoo", 0), Success((), 0))
+      }
     }
   }
 }

--- a/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ParsingTests.scala
@@ -103,6 +103,10 @@ object ParsingTests extends TestSuite{
         check(("Hello" ~ "Bye").?, ("HelloBoo", 0), Success((), 0))
         checkFail(("Hello" ~/ "Bye").?, ("HelloBoo", 0), 5)
       }
+      'flatMap{
+        checkFail(("Hello" ~/ "Boo").flatMap(_ => Fail).?, ("HelloBoo", 0), 8)
+        checkFail((("Hello" ~/ "Boo").flatMap(_ => Pass) ~ Fail).?, ("HelloBoo", 0), 8)
+      }
     }
   }
 }


### PR DESCRIPTION
We were not properly propagating the `cut`s in the LHS of `flatMap`s; that meant that if there was a `cut` inside the left hand parser, it doesn't take effect if something fails in the RHS of the `flatMap` call, or if the `flatMap` succeeds but something fails later.

Also makes `!` and `&` negative/positive lookaheads behave as `NoCut`s: the whole point of those operators is to backtrack, so there isn't any conceivable use-case where someone would want to use them and have a cut disable-backtracking/drop-buffer when inside one of these operators.

Also properly propagates cuts in `foo.filter(pred)` when `foo` passes but `pred` fails.

Found these when investigating the build failure in https://github.com/lihaoyi/fastparse/pull/122. Possibly not the only issue, but it's something. This changes behavior, but if this makes any tests fail, I'll fix them.

Review by @vovapolu 