### PR TITLE
Convert fastparse.byte to use scodec.bits.ByteVector instead of Array[Byte]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,8 @@ lazy val utils = crossProject
     unmanagedSourceDirectories in Compile ++= {
       if (scalaVersion.value startsWith "2.10.") Seq(baseDirectory.value / ".."/"shared"/"src"/ "main" / "scala-2.10")
       else Seq(baseDirectory.value / ".."/"shared" / "src"/"main" / "scala-2.11")
-    }
+    },
+    libraryDependencies += "org.scodec" %%% "scodec-bits" % "1.1.0"
   )
 lazy val utilsJS = utils.js
 lazy val utilsJVM= utils.jvm
@@ -101,7 +102,8 @@ lazy val fastparse = crossProject
         """.stripMargin
       IO.write(file, output)
       Seq(file)
-    }
+    },
+    libraryDependencies += "org.scodec" %%% "scodec-bits" % "1.1.0"
   )
   // In order to make the midi-parser-test in fastparseJVM/test:run work
   .jvmSettings(fork in (Test, run) := true)

--- a/classparse/jvm/src/test/scala/classparse/ProjectTests.scala
+++ b/classparse/jvm/src/test/scala/classparse/ProjectTests.scala
@@ -35,7 +35,7 @@ object ProjectTests extends TestSuite {
           javaClassOpt match {
             case Some(javaClass) =>
               print(".")
-              val classFile = fastparse.byte.ByteVector.view(
+              val classFile = fastparse.byte.Bytes.view(
                 Files.readAllBytes(Paths.get(classesPath + relativePath + ".class"))
               )
               TestUtils.checkClassAndClassFile(javaClass, classFile)

--- a/classparse/jvm/src/test/scala/classparse/ProjectTests.scala
+++ b/classparse/jvm/src/test/scala/classparse/ProjectTests.scala
@@ -35,7 +35,9 @@ object ProjectTests extends TestSuite {
           javaClassOpt match {
             case Some(javaClass) =>
               print(".")
-              val classFile = Files.readAllBytes(Paths.get(classesPath + relativePath + ".class"))
+              val classFile = fastparse.byte.ByteVector.view(
+                Files.readAllBytes(Paths.get(classesPath + relativePath + ".class"))
+              )
               TestUtils.checkClassAndClassFile(javaClass, classFile)
             case None =>
               print("-")

--- a/classparse/shared/src/main/scala/classparse/ClassAttributes.scala
+++ b/classparse/shared/src/main/scala/classparse/ClassAttributes.scala
@@ -11,16 +11,16 @@ object ClassAttributes {
 
   sealed abstract class Attribute
 
-  case class BasicAttribute(name: String, info: Array[Byte]) extends Attribute {
+  case class BasicAttribute(name: String, info: ByteVector) extends Attribute {
     override def equals(other: Any): Boolean =
       other match {
-        case attr: BasicAttribute => name == attr.name && info.deep == attr.info.deep
+        case attr: BasicAttribute => name == attr.name && info == attr.info
         case _ => false
       }
 
     override def toString = {
       import fastparse.ElemTypeFormatter.ByteFormatter
-      s"BasicAttribute($name,${ByteFormatter.prettyPrint(info)})"
+      s"BasicAttribute($name,${ByteFormatter.prettyPrint(info.toArray)})"
     }
   }
 
@@ -109,7 +109,7 @@ object ClassAttributes {
 
       P( inner_class_info_index ~ outer_class_info_index ~
          inner_name_index ~ inner_class_access_flags ).map {
-        case (inIdx: Int, outIdx: Int, inName: Int, inFlags: Array[Byte]) =>
+        case (inIdx: Int, outIdx: Int, inName: Int, inFlags: ByteVector) =>
           (classInfo: ClassFileInfo) => InnerClass(
             Class(classInfo, classInfo.getInfoByIndex[ClassInfo](inIdx).get),
             if (outIdx == 0) None

--- a/classparse/shared/src/main/scala/classparse/ClassAttributes.scala
+++ b/classparse/shared/src/main/scala/classparse/ClassAttributes.scala
@@ -11,7 +11,7 @@ object ClassAttributes {
 
   sealed abstract class Attribute
 
-  case class BasicAttribute(name: String, info: ByteVector) extends Attribute {
+  case class BasicAttribute(name: String, info: Bytes) extends Attribute {
     override def equals(other: Any): Boolean =
       other match {
         case attr: BasicAttribute => name == attr.name && info == attr.info
@@ -109,7 +109,7 @@ object ClassAttributes {
 
       P( inner_class_info_index ~ outer_class_info_index ~
          inner_name_index ~ inner_class_access_flags ).map {
-        case (inIdx: Int, outIdx: Int, inName: Int, inFlags: ByteVector) =>
+        case (inIdx: Int, outIdx: Int, inName: Int, inFlags: Bytes) =>
           (classInfo: ClassFileInfo) => InnerClass(
             Class(classInfo, classInfo.getInfoByIndex[ClassInfo](inIdx).get),
             if (outIdx == 0) None

--- a/classparse/shared/src/main/scala/classparse/ClassParse.scala
+++ b/classparse/shared/src/main/scala/classparse/ClassParse.scala
@@ -38,8 +38,8 @@ object ClassParse {
 
     case class NameAndTypeInfo(nameIndex: Int, descriptorIndex: Int) extends PoolInfo
 
-    case class Utf8Info(bytes: Array[Byte]) extends PoolInfo {
-      lazy val getString = new String(bytes, "UTF-8")
+    case class Utf8Info(bytes: ByteVector) extends PoolInfo {
+      lazy val getString = new String(bytes.toArray, "UTF-8")
     }
 
     case class MethodHandleInfo(referenceKind: Int, referenceIndex: Int) extends PoolInfo
@@ -48,16 +48,16 @@ object ClassParse {
 
     case class InvokeDynamicInfo(bootstrapMethodAttrIndex: Int, nameAndTypeIndex: Int) extends PoolInfo
 
-    case class AttributeInfo(nameIndex: Int, info: Array[Byte])
+    case class AttributeInfo(nameIndex: Int, info: ByteVector)
 
-    case class FieldInfo(accessFlags: Array[Byte], nameIndex: Int,
+    case class FieldInfo(accessFlags: ByteVector, nameIndex: Int,
                          descriptorIndex: Int,     attributes: Seq[AttributeInfo])
 
-    case class MethodInfo(accessFlags: Array[Byte], nameIndex: Int,
+    case class MethodInfo(accessFlags: ByteVector, nameIndex: Int,
                           descriptorIndex: Int,     attributes: Seq[AttributeInfo])
 
     case class ClassFileInfo(minorVersion: Int,           majorVersion: Int,
-                             pool: Seq[PoolInfo],         accessFlags: Array[Byte],
+                             pool: Seq[PoolInfo],         accessFlags: ByteVector,
                              thisClassIndex: Int,         superClassIndex: Int,
                              interfacesIndexes: Seq[Int], fields: Seq[FieldInfo],
                              methods: Seq[MethodInfo],    attributes: Seq[AttributeInfo]) {
@@ -209,7 +209,7 @@ object ClassParse {
                                accAbstract: Boolean, accSynthetic: Boolean, accAnnotation: Boolean,
                                accEnum: Boolean){
 
-      def this(fs: Array[Byte]) = this(
+      def this(fs: ByteVector) = this(
         getFlag(fs(1), 0x01), getFlag(fs(1), 0x02), getFlag(fs(1), 0x04),
         getFlag(fs(1), 0x08), getFlag(fs(1), 0x10), getFlag(fs(0), 0x02),
         getFlag(fs(0), 0x04), getFlag(fs(0), 0x10), getFlag(fs(0), 0x20),
@@ -218,21 +218,21 @@ object ClassParse {
 
 
     object InnerClassFlags {
-      def apply(fs: Array[Byte]) = new InnerClassFlags(fs)
+      def apply(fs: ByteVector) = new InnerClassFlags(fs)
     }
 
     case class FieldFlags(accPublic: Boolean,    accPrivate: Boolean,   accProtected: Boolean,
                           accStatic: Boolean,    accFinal: Boolean,     accVolatile: Boolean,
                           accTransient: Boolean, accSynthetic: Boolean, accEnum: Boolean) {
 
-      def this(fs: Array[Byte]) = this(
+      def this(fs: ByteVector) = this(
         getFlag(fs(1), 0x01), getFlag(fs(1), 0x02), getFlag(fs(1), 0x04),
         getFlag(fs(1), 0x08), getFlag(fs(1), 0x10), getFlag(fs(1), 0x40),
         getFlag(fs(1), 0x80), getFlag(fs(0), 0x10), getFlag(fs(0), 0x40))
     }
 
     object FieldFlags {
-      def apply(fs: Array[Byte]) = new FieldFlags(fs)
+      def apply(fs: ByteVector) = new FieldFlags(fs)
     }
 
     case class MethodFlags(accPublic: Boolean,    accPrivate: Boolean,   accProtected: Boolean,
@@ -240,7 +240,7 @@ object ClassParse {
                            accBridge: Boolean,    accVarargs: Boolean,   accNative: Boolean,
                            accAbstract: Boolean,  accStrict: Boolean,    accSynthetic: Boolean) {
 
-      def this(fs: Array[Byte]) = this(
+      def this(fs: ByteVector) = this(
         getFlag(fs(1), 0x01), getFlag(fs(1), 0x02), getFlag(fs(1), 0x04),
         getFlag(fs(1), 0x08), getFlag(fs(1), 0x10), getFlag(fs(1), 0x20),
         getFlag(fs(1), 0x40), getFlag(fs(1), 0x80), getFlag(fs(0), 0x01),
@@ -248,21 +248,21 @@ object ClassParse {
     }
 
     object MethodFlags {
-      def apply(fs: Array[Byte]) = new MethodFlags(fs)
+      def apply(fs: ByteVector) = new MethodFlags(fs)
     }
 
     case class ClassFlags(accPublic: Boolean,     accFinal: Boolean,    accSuper: Boolean,
                           accInterface: Boolean,  accAbstract: Boolean, accSynthetic: Boolean,
                           accAnnotation: Boolean, accEnum: Boolean){
 
-      def this(fs: Array[Byte]) = this(
+      def this(fs: ByteVector) = this(
         getFlag(fs(1), 0x01), getFlag(fs(1), 0x10), getFlag(fs(1), 0x20),
         getFlag(fs(0), 0x02), getFlag(fs(0), 0x04), getFlag(fs(0), 0x10),
         getFlag(fs(0), 0x20), getFlag(fs(0), 0x40))
     }
 
     object ClassFlags {
-      def apply(fs: Array[Byte]) = new ClassFlags(fs)
+      def apply(fs: ByteVector) = new ClassFlags(fs)
     }
 
     case class Field(name: String, descriptor: String, flags: FieldFlags, attributes: Seq[Attribute])

--- a/classparse/shared/src/main/scala/classparse/ClassParse.scala
+++ b/classparse/shared/src/main/scala/classparse/ClassParse.scala
@@ -38,7 +38,7 @@ object ClassParse {
 
     case class NameAndTypeInfo(nameIndex: Int, descriptorIndex: Int) extends PoolInfo
 
-    case class Utf8Info(bytes: ByteVector) extends PoolInfo {
+    case class Utf8Info(bytes: Bytes) extends PoolInfo {
       lazy val getString = new String(bytes.toArray, "UTF-8")
     }
 
@@ -48,19 +48,19 @@ object ClassParse {
 
     case class InvokeDynamicInfo(bootstrapMethodAttrIndex: Int, nameAndTypeIndex: Int) extends PoolInfo
 
-    case class AttributeInfo(nameIndex: Int, info: ByteVector)
+    case class AttributeInfo(nameIndex: Int, info: Bytes)
 
-    case class FieldInfo(accessFlags: ByteVector, nameIndex: Int,
-                         descriptorIndex: Int,     attributes: Seq[AttributeInfo])
+    case class FieldInfo(accessFlags: Bytes, nameIndex: Int,
+                         descriptorIndex: Int, attributes: Seq[AttributeInfo])
 
-    case class MethodInfo(accessFlags: ByteVector, nameIndex: Int,
-                          descriptorIndex: Int,     attributes: Seq[AttributeInfo])
+    case class MethodInfo(accessFlags: Bytes, nameIndex: Int,
+                          descriptorIndex: Int, attributes: Seq[AttributeInfo])
 
-    case class ClassFileInfo(minorVersion: Int,           majorVersion: Int,
-                             pool: Seq[PoolInfo],         accessFlags: ByteVector,
-                             thisClassIndex: Int,         superClassIndex: Int,
+    case class ClassFileInfo(minorVersion: Int, majorVersion: Int,
+                             pool: Seq[PoolInfo], accessFlags: Bytes,
+                             thisClassIndex: Int, superClassIndex: Int,
                              interfacesIndexes: Seq[Int], fields: Seq[FieldInfo],
-                             methods: Seq[MethodInfo],    attributes: Seq[AttributeInfo]) {
+                             methods: Seq[MethodInfo], attributes: Seq[AttributeInfo]) {
 
       def getInfoByIndex[T](idx: Int): Option[T] = {
         if (idx > pool.length || idx <= 0) {
@@ -209,7 +209,7 @@ object ClassParse {
                                accAbstract: Boolean, accSynthetic: Boolean, accAnnotation: Boolean,
                                accEnum: Boolean){
 
-      def this(fs: ByteVector) = this(
+      def this(fs: Bytes) = this(
         getFlag(fs(1), 0x01), getFlag(fs(1), 0x02), getFlag(fs(1), 0x04),
         getFlag(fs(1), 0x08), getFlag(fs(1), 0x10), getFlag(fs(0), 0x02),
         getFlag(fs(0), 0x04), getFlag(fs(0), 0x10), getFlag(fs(0), 0x20),
@@ -218,21 +218,21 @@ object ClassParse {
 
 
     object InnerClassFlags {
-      def apply(fs: ByteVector) = new InnerClassFlags(fs)
+      def apply(fs: Bytes) = new InnerClassFlags(fs)
     }
 
     case class FieldFlags(accPublic: Boolean,    accPrivate: Boolean,   accProtected: Boolean,
                           accStatic: Boolean,    accFinal: Boolean,     accVolatile: Boolean,
                           accTransient: Boolean, accSynthetic: Boolean, accEnum: Boolean) {
 
-      def this(fs: ByteVector) = this(
+      def this(fs: Bytes) = this(
         getFlag(fs(1), 0x01), getFlag(fs(1), 0x02), getFlag(fs(1), 0x04),
         getFlag(fs(1), 0x08), getFlag(fs(1), 0x10), getFlag(fs(1), 0x40),
         getFlag(fs(1), 0x80), getFlag(fs(0), 0x10), getFlag(fs(0), 0x40))
     }
 
     object FieldFlags {
-      def apply(fs: ByteVector) = new FieldFlags(fs)
+      def apply(fs: Bytes) = new FieldFlags(fs)
     }
 
     case class MethodFlags(accPublic: Boolean,    accPrivate: Boolean,   accProtected: Boolean,
@@ -240,7 +240,7 @@ object ClassParse {
                            accBridge: Boolean,    accVarargs: Boolean,   accNative: Boolean,
                            accAbstract: Boolean,  accStrict: Boolean,    accSynthetic: Boolean) {
 
-      def this(fs: ByteVector) = this(
+      def this(fs: Bytes) = this(
         getFlag(fs(1), 0x01), getFlag(fs(1), 0x02), getFlag(fs(1), 0x04),
         getFlag(fs(1), 0x08), getFlag(fs(1), 0x10), getFlag(fs(1), 0x20),
         getFlag(fs(1), 0x40), getFlag(fs(1), 0x80), getFlag(fs(0), 0x01),
@@ -248,21 +248,21 @@ object ClassParse {
     }
 
     object MethodFlags {
-      def apply(fs: ByteVector) = new MethodFlags(fs)
+      def apply(fs: Bytes) = new MethodFlags(fs)
     }
 
     case class ClassFlags(accPublic: Boolean,     accFinal: Boolean,    accSuper: Boolean,
                           accInterface: Boolean,  accAbstract: Boolean, accSynthetic: Boolean,
                           accAnnotation: Boolean, accEnum: Boolean){
 
-      def this(fs: ByteVector) = this(
+      def this(fs: Bytes) = this(
         getFlag(fs(1), 0x01), getFlag(fs(1), 0x10), getFlag(fs(1), 0x20),
         getFlag(fs(0), 0x02), getFlag(fs(0), 0x04), getFlag(fs(0), 0x10),
         getFlag(fs(0), 0x20), getFlag(fs(0), 0x40))
     }
 
     object ClassFlags {
-      def apply(fs: ByteVector) = new ClassFlags(fs)
+      def apply(fs: Bytes) = new ClassFlags(fs)
     }
 
     case class Field(name: String, descriptor: String, flags: FieldFlags, attributes: Seq[Attribute])

--- a/classparse/shared/src/main/scala/classparse/CodeParser.scala
+++ b/classparse/shared/src/main/scala/classparse/CodeParser.scala
@@ -416,10 +416,10 @@ object CodeParser {
       0x11 -> P( UInt16 ).map(i => i.toShort).map(SIPush),
       0xbc -> P( AnyByte.! ).map(_(0)).map(NewArray),
       0x84 -> P( AnyByte.! ~ AnyByte.!).map {
-        case (idx: ByteVector, const: ByteVector) => IInc(idx(0) & 0xff, const(0).toInt)
+        case (idx: Bytes, const: Bytes) => IInc(idx(0) & 0xff, const(0).toInt)
       },
       0xc5 -> P( UInt16 ~ AnyByte.! ).map {
-        case (index: Int, dims: ByteVector) => MutliANewArray(index, dims(0) & 0xff)
+        case (index: Int, dims: Bytes) => MutliANewArray(index, dims(0) & 0xff)
       },
 
       0x19 -> localIndex.map(ALoad),
@@ -473,7 +473,7 @@ object CodeParser {
 
       0xba -> P( UInt16 ~ BS(0, 0) ).map(InvokeDynamic),
       0xb9 -> P( UInt16 ~ AnyByte.! ~ BS(0) ).map {
-        case (idx: Int, count: ByteVector) => InvokeInterface(idx, count(0) & 0xff)
+        case (idx: Int, count: Bytes) => InvokeInterface(idx, count(0) & 0xff)
       },
 
       0xab ->
@@ -495,10 +495,10 @@ object CodeParser {
     )
   }
 
-  def parseCode(code: ByteVector): Seq[OpCode] = {
+  def parseCode(code: Bytes): Seq[OpCode] = {
     val opCodes =
       P( (AnyByte.! ~ Index).flatMap {
-          case (bs: ByteVector, idx: Int) => (bs(0) & 0xff) match {
+          case (bs: Bytes, idx: Int) => (bs(0) & 0xff) match {
             case b @ (0xab | 0xaa) => AnyBytes((4 - idx % 4) % 4) ~ opCodeParsers(b)
             case b: Int => opCodeParsers(b)
           }

--- a/classparse/shared/src/main/scala/classparse/CodeParser.scala
+++ b/classparse/shared/src/main/scala/classparse/CodeParser.scala
@@ -416,10 +416,10 @@ object CodeParser {
       0x11 -> P( UInt16 ).map(i => i.toShort).map(SIPush),
       0xbc -> P( AnyByte.! ).map(_(0)).map(NewArray),
       0x84 -> P( AnyByte.! ~ AnyByte.!).map {
-        case (idx: Array[Byte], const: Array[Byte]) => IInc(idx(0) & 0xff, const(0).toInt)
+        case (idx: ByteVector, const: ByteVector) => IInc(idx(0) & 0xff, const(0).toInt)
       },
       0xc5 -> P( UInt16 ~ AnyByte.! ).map {
-        case (index: Int, dims: Array[Byte]) => MutliANewArray(index, dims(0) & 0xff)
+        case (index: Int, dims: ByteVector) => MutliANewArray(index, dims(0) & 0xff)
       },
 
       0x19 -> localIndex.map(ALoad),
@@ -473,7 +473,7 @@ object CodeParser {
 
       0xba -> P( UInt16 ~ BS(0, 0) ).map(InvokeDynamic),
       0xb9 -> P( UInt16 ~ AnyByte.! ~ BS(0) ).map {
-        case (idx: Int, count: Array[Byte]) => InvokeInterface(idx, count(0) & 0xff)
+        case (idx: Int, count: ByteVector) => InvokeInterface(idx, count(0) & 0xff)
       },
 
       0xab ->
@@ -495,10 +495,10 @@ object CodeParser {
     )
   }
 
-  def parseCode(code: Array[Byte]): Seq[OpCode] = {
+  def parseCode(code: ByteVector): Seq[OpCode] = {
     val opCodes =
       P( (AnyByte.! ~ Index).flatMap {
-          case (bs: Array[Byte], idx: Int) => (bs(0) & 0xff) match {
+          case (bs: ByteVector, idx: Int) => (bs(0) & 0xff) match {
             case b @ (0xab | 0xaa) => AnyBytes((4 - idx % 4) % 4) ~ opCodeParsers(b)
             case b: Int => opCodeParsers(b)
           }

--- a/classparse/shared/src/test/scala/classparse/ClassTests.scala
+++ b/classparse/shared/src/test/scala/classparse/ClassTests.scala
@@ -19,31 +19,33 @@ object ClassTests extends TestSuite {
 
     'basic {
       'book {
-        val classFile = hexBytes("CA FE BA BE " +
-          "00 00 00 34 00 1D 0A 00 05 00 18 09 00 04 00 19 09 00 04 00 1A 07 00 " +
-          "1B 07 00 1C 01 00 05 74 69 74 6C 65 01 00 12 4C 6A 61 76 61 2F 6C 61 " +
-          "6E 67 2F 53 74 72 69 6E 67 3B 01 00 07 70 75 62 59 65 61 72 01 00 01 " +
-          "49 01 00 06 3C 69 6E 69 74 3E 01 00 03 28 29 56 01 00 04 43 6F 64 65 " +
-          "01 00 0F 4C 69 6E 65 4E 75 6D 62 65 72 54 61 62 6C 65 01 00 08 67 65 " +
-          "74 54 69 74 6C 65 01 00 14 28 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 " +
-          "74 72 69 6E 67 3B 01 00 0A 67 65 74 50 75 62 59 65 61 72 01 00 03 28 " +
-          "29 49 01 00 08 73 65 74 54 69 74 6C 65 01 00 15 28 4C 6A 61 76 61 2F " +
-          "6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 56 01 00 0A 73 65 74 50 75 62 " +
-          "59 65 61 72 01 00 04 28 49 29 56 01 00 0A 53 6F 75 72 63 65 46 69 6C " +
-          "65 01 00 09 42 6F 6F 6B 2E 6A 61 76 61 0C 00 0A 00 0B 0C 00 06 00 07 " +
-          "0C 00 08 00 09 01 00 04 42 6F 6F 6B 01 00 10 6A 61 76 61 2F 6C 61 6E " +
-          "67 2F 4F 62 6A 65 63 74 00 20 00 04 00 05 00 00 00 02 00 02 00 06 00 " +
-          "07 00 00 00 02 00 08 00 09 00 00 00 05 00 00 00 0A 00 0B 00 01 00 0C " +
-          "00 00 00 1D 00 01 00 01 00 00 00 05 2A B7 00 01 B1 00 00 00 01 00 0D " +
-          "00 00 00 06 00 01 00 00 00 01 00 01 00 0E 00 0F 00 01 00 0C 00 00 00 " +
-          "1D 00 01 00 01 00 00 00 05 2A B4 00 02 B0 00 00 00 01 00 0D 00 00 00 " +
-          "06 00 01 00 00 00 06 00 01 00 10 00 11 00 01 00 0C 00 00 00 1D 00 01 " +
-          "00 01 00 00 00 05 2A B4 00 03 AC 00 00 00 01 00 0D 00 00 00 06 00 01 " +
-          "00 00 00 0A 00 01 00 12 00 13 00 01 00 0C 00 00 00 22 00 02 00 02 00 " +
-          "00 00 06 2A 2B B5 00 02 B1 00 00 00 01 00 0D 00 00 00 0A 00 02 00 00 " +
-          "00 0E 00 05 00 0F 00 01 00 14 00 15 00 01 00 0C 00 00 00 22 00 02 00 " +
-          "02 00 00 00 06 2A 1B B5 00 03 B1 00 00 00 01 00 0D 00 00 00 0A 00 02 " +
-          "00 00 00 12 00 05 00 13 00 01 00 16 00 00 00 02 00 17")
+        val classFile = hex"""
+          CA FE BA BE
+          00 00 00 34 00 1D 0A 00 05 00 18 09 00 04 00 19 09 00 04 00 1A 07 00
+          1B 07 00 1C 01 00 05 74 69 74 6C 65 01 00 12 4C 6A 61 76 61 2F 6C 61
+          6E 67 2F 53 74 72 69 6E 67 3B 01 00 07 70 75 62 59 65 61 72 01 00 01
+          49 01 00 06 3C 69 6E 69 74 3E 01 00 03 28 29 56 01 00 04 43 6F 64 65
+          01 00 0F 4C 69 6E 65 4E 75 6D 62 65 72 54 61 62 6C 65 01 00 08 67 65
+          74 54 69 74 6C 65 01 00 14 28 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53
+          74 72 69 6E 67 3B 01 00 0A 67 65 74 50 75 62 59 65 61 72 01 00 03 28
+          29 49 01 00 08 73 65 74 54 69 74 6C 65 01 00 15 28 4C 6A 61 76 61 2F
+          6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 56 01 00 0A 73 65 74 50 75 62
+          59 65 61 72 01 00 04 28 49 29 56 01 00 0A 53 6F 75 72 63 65 46 69 6C
+          65 01 00 09 42 6F 6F 6B 2E 6A 61 76 61 0C 00 0A 00 0B 0C 00 06 00 07
+          0C 00 08 00 09 01 00 04 42 6F 6F 6B 01 00 10 6A 61 76 61 2F 6C 61 6E
+          67 2F 4F 62 6A 65 63 74 00 20 00 04 00 05 00 00 00 02 00 02 00 06 00
+          07 00 00 00 02 00 08 00 09 00 00 00 05 00 00 00 0A 00 0B 00 01 00 0C
+          00 00 00 1D 00 01 00 01 00 00 00 05 2A B7 00 01 B1 00 00 00 01 00 0D
+          00 00 00 06 00 01 00 00 00 01 00 01 00 0E 00 0F 00 01 00 0C 00 00 00
+          1D 00 01 00 01 00 00 00 05 2A B4 00 02 B0 00 00 00 01 00 0D 00 00 00
+          06 00 01 00 00 00 06 00 01 00 10 00 11 00 01 00 0C 00 00 00 1D 00 01
+          00 01 00 00 00 05 2A B4 00 03 AC 00 00 00 01 00 0D 00 00 00 06 00 01
+          00 00 00 0A 00 01 00 12 00 13 00 01 00 0C 00 00 00 22 00 02 00 02 00
+          00 00 06 2A 2B B5 00 02 B1 00 00 00 01 00 0D 00 00 00 0A 00 02 00 00
+          00 0E 00 05 00 0F 00 01 00 14 00 15 00 01 00 0C 00 00 00 22 00 02 00
+          02 00 00 00 06 2A 1B B5 00 03 B1 00 00 00 01 00 0D 00 00 00 0A 00 02
+          00 00 00 12 00 05 00 13 00 01 00 16 00 00 00 02 00 17
+        """
         /* Book.class from compiled class Book.java */
 
         val expected = ClassFile(0, 52,
@@ -98,7 +100,7 @@ object ClassTests extends TestSuite {
                 CodeAttribute(1, 1,
                   ArrayBuffer(ALoad0, InvokeSpecial(1), Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 01")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 01 00 00 00 01"))
                 )
               )
             ),
@@ -109,7 +111,7 @@ object ClassTests extends TestSuite {
                 CodeAttribute(1, 1,
                   ArrayBuffer(ALoad0, GetField(2), AReturn),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 06")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 01 00 00 00 06"))
                 )
               )
             ),
@@ -120,7 +122,7 @@ object ClassTests extends TestSuite {
                 CodeAttribute(1, 1,
                   ArrayBuffer(ALoad0, GetField(3), IReturn),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 0A")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 01 00 00 00 0A"))
                 )
               )
             ),
@@ -131,7 +133,7 @@ object ClassTests extends TestSuite {
                 CodeAttribute(2, 2,
                   ArrayBuffer(ALoad0, ALoad1, PutField(2), Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 02 00 00 00 0E 00 05 00 0F")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 02 00 00 00 0E 00 05 00 0F"))
                 )
               )
             ),
@@ -142,7 +144,7 @@ object ClassTests extends TestSuite {
                 CodeAttribute(2, 2,
                   ArrayBuffer(ALoad0, ILoad1, PutField(3), Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 02 00 00 00 12 00 05 00 13")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 02 00 00 00 12 00 05 00 13"))
                 )
               )
             )
@@ -157,7 +159,7 @@ object ClassTests extends TestSuite {
 
         for(chunkSize <- Seq(1, 4, 16, 64, 256, 1024)){
           val Parsed.Success(parsedClassInfo, _) = ClassParse.classFile.parseIterator(
-            classFile.toArray.grouped(chunkSize).map(ByteVector.view)
+            classFile.toArray.grouped(chunkSize).map(Bytes.view)
           )
           val parsedClass = ClassParse.Ast.convertToAst(parsedClassInfo)
 
@@ -166,72 +168,74 @@ object ClassTests extends TestSuite {
       }
 
       'book2 {
-        val classFile = hexBytes("CA FE BA BE " +
-          "00 00 00 34 00 4D 0A 00 12 00 34 09 00 11 00 35 09 00 11 00 36 09 " +
-          "00 11 00 37 09 00 11 00 38 08 00 39 08 00 3A 08 00 3B 08 00 3C 07 " +
-          "00 3D 0A 00 0A 00 34 0A 00 0A 00 3E 08 00 3F 0A 00 40 00 41 0A 00 " +
-          "13 00 42 0A 00 0A 00 43 07 00 44 07 00 45 07 00 46 01 00 05 47 65 " +
-          "6E 72 65 01 00 0C 49 6E 6E 65 72 43 6C 61 73 73 65 73 01 00 05 74 " +
-          "69 74 6C 65 01 00 12 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 " +
-          "6E 67 3B 01 00 07 70 75 62 59 65 61 72 01 00 01 49 01 00 05 67 65 " +
-          "6E 72 65 01 00 0D 4C 42 6F 6F 6B 32 24 47 65 6E 72 65 3B 01 00 06 " +
-          "63 6F 70 69 65 73 01 00 06 3C 69 6E 69 74 3E 01 00 03 28 29 56 01 " +
-          "00 04 43 6F 64 65 01 00 0F 4C 69 6E 65 4E 75 6D 62 65 72 54 61 62 " +
-          "6C 65 01 00 08 67 65 74 54 69 74 6C 65 01 00 14 28 29 4C 6A 61 76 " +
-          "61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 01 00 0A 67 65 74 50 75 " +
-          "62 59 65 61 72 01 00 03 28 29 49 01 00 08 67 65 74 47 65 6E 67 65 " +
-          "01 00 0F 28 29 4C 42 6F 6F 6B 32 24 47 65 6E 72 65 3B 01 00 09 67 " +
-          "65 74 43 6F 70 69 65 73 01 00 08 73 65 74 54 69 74 6C 65 01 00 15 " +
-          "28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 56 01 " +
-          "00 0A 73 65 74 50 75 62 59 65 61 72 01 00 04 28 49 29 56 01 00 08 " +
-          "73 65 74 47 65 6E 72 65 01 00 10 28 4C 42 6F 6F 6B 32 24 47 65 6E " +
-          "72 65 3B 29 56 01 00 09 73 65 74 43 6F 70 69 65 73 01 00 08 74 6F " +
-          "53 74 72 69 6E 67 01 00 0D 53 74 61 63 6B 4D 61 70 54 61 62 6C 65 " +
-          "07 00 47 01 00 0A 53 6F 75 72 63 65 46 69 6C 65 01 00 0A 42 6F 6F " +
-          "6B 32 2E 6A 61 76 61 0C 00 1D 00 1E 0C 00 16 00 17 0C 00 18 00 19 " +
-          "0C 00 1A 00 1B 0C 00 1C 00 19 01 00 09 4E 6F 20 63 6F 70 69 65 73 " +
-          "01 00 0D 4F 6E 6C 79 20 6F 6E 65 20 63 6F 70 79 01 00 0A 54 77 6F " +
-          "20 63 6F 70 69 65 73 01 00 10 41 20 6C 6F 74 20 6F 66 20 63 6F 70 " +
-          "69 65 73 21 01 00 17 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E " +
-          "67 42 75 69 6C 64 65 72 0C 00 48 00 49 01 00 01 20 07 00 47 0C 00 " +
-          "4A 00 4B 0C 00 4C 00 22 0C 00 2F 00 22 01 00 05 42 6F 6F 6B 32 01 " +
-          "00 10 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 01 00 0B 42 " +
-          "6F 6F 6B 32 24 47 65 6E 72 65 01 00 10 6A 61 76 61 2F 6C 61 6E 67 " +
-          "2F 53 74 72 69 6E 67 01 00 06 61 70 70 65 6E 64 01 00 2D 28 4C 6A " +
-          "61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 4C 6A 61 76 61 " +
-          "2F 6C 61 6E 67 2F 53 74 72 69 6E 67 42 75 69 6C 64 65 72 3B 01 00 " +
-          "07 76 61 6C 75 65 4F 66 01 00 15 28 49 29 4C 6A 61 76 61 2F 6C 61 " +
-          "6E 67 2F 53 74 72 69 6E 67 3B 01 00 04 6E 61 6D 65 00 20 00 11 00 " +
-          "12 00 00 00 04 00 02 00 16 00 17 00 00 00 02 00 18 00 19 00 00 00 " +
-          "02 00 1A 00 1B 00 00 00 02 00 1C 00 19 00 00 00 0A 00 00 00 1D 00 " +
-          "1E 00 01 00 1F 00 00 00 1D 00 01 00 01 00 00 00 05 2A B7 00 01 B1 " +
-          "00 00 00 01 00 20 00 00 00 06 00 01 00 00 00 01 00 01 00 21 00 22 " +
-          "00 01 00 1F 00 00 00 1D 00 01 00 01 00 00 00 05 2A B4 00 02 B0 00 " +
-          "00 00 01 00 20 00 00 00 06 00 01 00 00 00 0A 00 01 00 23 00 24 00 " +
-          "01 00 1F 00 00 00 1D 00 01 00 01 00 00 00 05 2A B4 00 03 AC 00 00 " +
-          "00 01 00 20 00 00 00 06 00 01 00 00 00 0E 00 01 00 25 00 26 00 01 " +
-          "00 1F 00 00 00 1D 00 01 00 01 00 00 00 05 2A B4 00 04 B0 00 00 00 " +
-          "01 00 20 00 00 00 06 00 01 00 00 00 12 00 01 00 27 00 24 00 01 00 " +
-          "1F 00 00 00 1D 00 01 00 01 00 00 00 05 2A B4 00 05 AC 00 00 00 01 " +
-          "00 20 00 00 00 06 00 01 00 00 00 16 00 01 00 28 00 29 00 01 00 1F " +
-          "00 00 00 22 00 02 00 02 00 00 00 06 2A 2B B5 00 02 B1 00 00 00 01 " +
-          "00 20 00 00 00 0A 00 02 00 00 00 1A 00 05 00 1B 00 01 00 2A 00 2B " +
-          "00 01 00 1F 00 00 00 22 00 02 00 02 00 00 00 06 2A 1B B5 00 03 B1 " +
-          "00 00 00 01 00 20 00 00 00 0A 00 02 00 00 00 1E 00 05 00 1F 00 01 " +
-          "00 2C 00 2D 00 01 00 1F 00 00 00 22 00 02 00 02 00 00 00 06 2A 2B " +
-          "B5 00 04 B1 00 00 00 01 00 20 00 00 00 0A 00 02 00 00 00 22 00 05 " +
-          "00 23 00 01 00 2E 00 2B 00 01 00 1F 00 00 00 22 00 02 00 02 00 00 " +
-          "00 06 2A 1B B5 00 05 B1 00 00 00 01 00 20 00 00 00 0A 00 02 00 00 " +
-          "00 26 00 05 00 27 00 01 00 2F 00 22 00 01 00 1F 00 00 00 AC 00 02 " +
-          "00 02 00 00 00 6E 2A B4 00 05 AA 00 00 00 00 00 00 2E 00 00 00 00 " +
-          "00 00 00 02 00 00 00 1C 00 00 00 22 00 00 00 28 12 06 4C A7 00 12 " +
-          "12 07 4C A7 00 0C 12 08 4C A7 00 06 12 09 4C BB 00 0A 59 B7 00 0B " +
-          "2A B4 00 02 B6 00 0C 12 0D B6 00 0C 2A B4 00 03 B8 00 0E B6 00 0C " +
-          "12 0D B6 00 0C 2A B4 00 04 B6 00 0F B6 00 0C 12 0D B6 00 0C 2B B6 " +
-          "00 0C B6 00 10 B0 00 00 00 02 00 20 00 00 00 1A 00 06 00 00 00 2C " +
-          "00 20 00 2D 00 26 00 2E 00 2C 00 2F 00 32 00 30 00 35 00 32 00 30 " +
-          "00 00 00 0C 00 05 20 05 05 05 FC 00 02 07 00 31 00 02 00 32 00 00 " +
-          "00 02 00 33 00 15 00 00 00 0A 00 01 00 13 00 11 00 14 40 19")
+        val classFile = hex"""
+          CA FE BA BE
+          00 00 00 34 00 4D 0A 00 12 00 34 09 00 11 00 35 09 00 11 00 36 09
+          00 11 00 37 09 00 11 00 38 08 00 39 08 00 3A 08 00 3B 08 00 3C 07
+          00 3D 0A 00 0A 00 34 0A 00 0A 00 3E 08 00 3F 0A 00 40 00 41 0A 00
+          13 00 42 0A 00 0A 00 43 07 00 44 07 00 45 07 00 46 01 00 05 47 65
+          6E 72 65 01 00 0C 49 6E 6E 65 72 43 6C 61 73 73 65 73 01 00 05 74
+          69 74 6C 65 01 00 12 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69
+          6E 67 3B 01 00 07 70 75 62 59 65 61 72 01 00 01 49 01 00 05 67 65
+          6E 72 65 01 00 0D 4C 42 6F 6F 6B 32 24 47 65 6E 72 65 3B 01 00 06
+          63 6F 70 69 65 73 01 00 06 3C 69 6E 69 74 3E 01 00 03 28 29 56 01
+          00 04 43 6F 64 65 01 00 0F 4C 69 6E 65 4E 75 6D 62 65 72 54 61 62
+          6C 65 01 00 08 67 65 74 54 69 74 6C 65 01 00 14 28 29 4C 6A 61 76
+          61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 01 00 0A 67 65 74 50 75
+          62 59 65 61 72 01 00 03 28 29 49 01 00 08 67 65 74 47 65 6E 67 65
+          01 00 0F 28 29 4C 42 6F 6F 6B 32 24 47 65 6E 72 65 3B 01 00 09 67
+          65 74 43 6F 70 69 65 73 01 00 08 73 65 74 54 69 74 6C 65 01 00 15
+          28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 56 01
+          00 0A 73 65 74 50 75 62 59 65 61 72 01 00 04 28 49 29 56 01 00 08
+          73 65 74 47 65 6E 72 65 01 00 10 28 4C 42 6F 6F 6B 32 24 47 65 6E
+          72 65 3B 29 56 01 00 09 73 65 74 43 6F 70 69 65 73 01 00 08 74 6F
+          53 74 72 69 6E 67 01 00 0D 53 74 61 63 6B 4D 61 70 54 61 62 6C 65
+          07 00 47 01 00 0A 53 6F 75 72 63 65 46 69 6C 65 01 00 0A 42 6F 6F
+          6B 32 2E 6A 61 76 61 0C 00 1D 00 1E 0C 00 16 00 17 0C 00 18 00 19
+          0C 00 1A 00 1B 0C 00 1C 00 19 01 00 09 4E 6F 20 63 6F 70 69 65 73
+          01 00 0D 4F 6E 6C 79 20 6F 6E 65 20 63 6F 70 79 01 00 0A 54 77 6F
+          20 63 6F 70 69 65 73 01 00 10 41 20 6C 6F 74 20 6F 66 20 63 6F 70
+          69 65 73 21 01 00 17 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E
+          67 42 75 69 6C 64 65 72 0C 00 48 00 49 01 00 01 20 07 00 47 0C 00
+          4A 00 4B 0C 00 4C 00 22 0C 00 2F 00 22 01 00 05 42 6F 6F 6B 32 01
+          00 10 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 01 00 0B 42
+          6F 6F 6B 32 24 47 65 6E 72 65 01 00 10 6A 61 76 61 2F 6C 61 6E 67
+          2F 53 74 72 69 6E 67 01 00 06 61 70 70 65 6E 64 01 00 2D 28 4C 6A
+          61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 4C 6A 61 76 61
+          2F 6C 61 6E 67 2F 53 74 72 69 6E 67 42 75 69 6C 64 65 72 3B 01 00
+          07 76 61 6C 75 65 4F 66 01 00 15 28 49 29 4C 6A 61 76 61 2F 6C 61
+          6E 67 2F 53 74 72 69 6E 67 3B 01 00 04 6E 61 6D 65 00 20 00 11 00
+          12 00 00 00 04 00 02 00 16 00 17 00 00 00 02 00 18 00 19 00 00 00
+          02 00 1A 00 1B 00 00 00 02 00 1C 00 19 00 00 00 0A 00 00 00 1D 00
+          1E 00 01 00 1F 00 00 00 1D 00 01 00 01 00 00 00 05 2A B7 00 01 B1
+          00 00 00 01 00 20 00 00 00 06 00 01 00 00 00 01 00 01 00 21 00 22
+          00 01 00 1F 00 00 00 1D 00 01 00 01 00 00 00 05 2A B4 00 02 B0 00
+          00 00 01 00 20 00 00 00 06 00 01 00 00 00 0A 00 01 00 23 00 24 00
+          01 00 1F 00 00 00 1D 00 01 00 01 00 00 00 05 2A B4 00 03 AC 00 00
+          00 01 00 20 00 00 00 06 00 01 00 00 00 0E 00 01 00 25 00 26 00 01
+          00 1F 00 00 00 1D 00 01 00 01 00 00 00 05 2A B4 00 04 B0 00 00 00
+          01 00 20 00 00 00 06 00 01 00 00 00 12 00 01 00 27 00 24 00 01 00
+          1F 00 00 00 1D 00 01 00 01 00 00 00 05 2A B4 00 05 AC 00 00 00 01
+          00 20 00 00 00 06 00 01 00 00 00 16 00 01 00 28 00 29 00 01 00 1F
+          00 00 00 22 00 02 00 02 00 00 00 06 2A 2B B5 00 02 B1 00 00 00 01
+          00 20 00 00 00 0A 00 02 00 00 00 1A 00 05 00 1B 00 01 00 2A 00 2B
+          00 01 00 1F 00 00 00 22 00 02 00 02 00 00 00 06 2A 1B B5 00 03 B1
+          00 00 00 01 00 20 00 00 00 0A 00 02 00 00 00 1E 00 05 00 1F 00 01
+          00 2C 00 2D 00 01 00 1F 00 00 00 22 00 02 00 02 00 00 00 06 2A 2B
+          B5 00 04 B1 00 00 00 01 00 20 00 00 00 0A 00 02 00 00 00 22 00 05
+          00 23 00 01 00 2E 00 2B 00 01 00 1F 00 00 00 22 00 02 00 02 00 00
+          00 06 2A 1B B5 00 05 B1 00 00 00 01 00 20 00 00 00 0A 00 02 00 00
+          00 26 00 05 00 27 00 01 00 2F 00 22 00 01 00 1F 00 00 00 AC 00 02
+          00 02 00 00 00 6E 2A B4 00 05 AA 00 00 00 00 00 00 2E 00 00 00 00
+          00 00 00 02 00 00 00 1C 00 00 00 22 00 00 00 28 12 06 4C A7 00 12
+          12 07 4C A7 00 0C 12 08 4C A7 00 06 12 09 4C BB 00 0A 59 B7 00 0B
+          2A B4 00 02 B6 00 0C 12 0D B6 00 0C 2A B4 00 03 B8 00 0E B6 00 0C
+          12 0D B6 00 0C 2A B4 00 04 B6 00 0F B6 00 0C 12 0D B6 00 0C 2B B6
+          00 0C B6 00 10 B0 00 00 00 02 00 20 00 00 00 1A 00 06 00 00 00 2C
+          00 20 00 2D 00 26 00 2E 00 2C 00 2F 00 32 00 30 00 35 00 32 00 30
+          00 00 00 0C 00 05 20 05 05 05 FC 00 02 07 00 31 00 02 00 32 00 00
+          00 02 00 33 00 15 00 00 00 0A 00 01 00 13 00 11 00 14 40 19
+        """
         /* Book2.class from compiled class Book2.java */
 
         val expected = ClassFile(0, 52,
@@ -354,7 +358,7 @@ object ClassTests extends TestSuite {
                     InvokeSpecial(1),
                     Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 01")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 01 00 00 00 01"))
                 )
               )
             ),
@@ -369,7 +373,7 @@ object ClassTests extends TestSuite {
                     GetField(2),
                     AReturn),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 0a")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 01 00 00 00 0a"))
                 )
               )
             ),
@@ -384,7 +388,7 @@ object ClassTests extends TestSuite {
                     GetField(3),
                     IReturn),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 0e")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 01 00 00 00 0e"))
                 )
               )
             ),
@@ -399,7 +403,7 @@ object ClassTests extends TestSuite {
                     GetField(4),
                     AReturn),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 12")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 01 00 00 00 12"))
                 )
               )
             ),
@@ -414,7 +418,7 @@ object ClassTests extends TestSuite {
                     GetField(5),
                     IReturn),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 01 00 00 00 16")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 01 00 00 00 16"))
                 )
               )
             ),
@@ -430,7 +434,7 @@ object ClassTests extends TestSuite {
                     PutField(2),
                     Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 02 00 00 00 1a 00 05 00 1b")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 02 00 00 00 1a 00 05 00 1b"))
                 )
               )
             ),
@@ -446,7 +450,7 @@ object ClassTests extends TestSuite {
                     PutField(3),
                     Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 02 00 00 00 1e 00 05 00 1f")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 02 00 00 00 1e 00 05 00 1f"))
                 )
               )
             ),
@@ -462,7 +466,7 @@ object ClassTests extends TestSuite {
                     PutField(4),
                     Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 02 00 00 00 22 00 05 00 23")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 02 00 00 00 22 00 05 00 23"))
                 )
               )
             ),
@@ -478,7 +482,7 @@ object ClassTests extends TestSuite {
                     PutField(5),
                     Return),
                   ArrayBuffer(),
-                  ArrayBuffer(BasicAttribute("LineNumberTable", hexBytes("00 02 00 00 00 26 00 05 00 27")))
+                  ArrayBuffer(BasicAttribute("LineNumberTable", hex"00 02 00 00 00 26 00 05 00 27"))
                 )
               )
             ),
@@ -531,11 +535,11 @@ object ClassTests extends TestSuite {
                   ArrayBuffer(
                     BasicAttribute(
                       "LineNumberTable",
-                      hexBytes("00 06 00 00 00 2c 00 20 00 2d 00 26 00 2e 00 2c 00 2f 00 32 00 30 00 35 00 32")
+                      hex"00 06 00 00 00 2c 00 20 00 2d 00 26 00 2e 00 2c 00 2f 00 32 00 30 00 35 00 32"
                     ),
                     BasicAttribute(
                       "StackMapTable",
-                      hexBytes("00 05 20 05 05 05 fc 00 02 07 00 31")
+                      hex"00 05 20 05 05 05 fc 00 02 07 00 31"
                     )
                   )
                 )
@@ -564,7 +568,7 @@ object ClassTests extends TestSuite {
 
         for(chunkSize <- Seq(1, 4, 16, 64, 256, 1024)){
           val Parsed.Success(parsedClassInfo, _) = ClassParse.classFile.parseIterator(
-            classFile.toArray.grouped(chunkSize).map(ByteVector.view)
+            classFile.toArray.grouped(chunkSize).map(Bytes.view)
           )
           val parsedClass = ClassParse.Ast.convertToAst(parsedClassInfo)
 
@@ -573,39 +577,41 @@ object ClassTests extends TestSuite {
       }
 
       'attributes {
-        val classFile = hexBytes("CA FE BA BE " +
-          "00 00 00 34 00 27 0A 00 08 00 1E 07 00 1F 0A 00 02 00 20 07 00 21 " +
-          "09 00 02 00 22 07 00 23 0A 00 06 00 1E 07 00 24 01 00 0A 49 6E 6E " +
-          "65 72 43 6C 61 73 73 01 00 0C 49 6E 6E 65 72 43 6C 61 73 73 65 73 " +
-          "01 00 09 43 4F 4E 53 54 5F 56 41 4C 01 00 01 49 01 00 0D 43 6F 6E " +
-          "73 74 61 6E 74 56 61 6C 75 65 03 00 00 00 2A 01 00 06 3C 69 6E 69 " +
-          "74 3E 01 00 03 28 29 56 01 00 04 43 6F 64 65 01 00 0F 4C 69 6E 65 " +
-          "4E 75 6D 62 65 72 54 61 62 6C 65 01 00 06 6D 65 74 68 6F 64 01 00 " +
-          "14 28 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 01 " +
-          "00 0A 45 78 63 65 70 74 69 6F 6E 73 01 00 0A 44 65 70 72 65 63 61 " +
-          "74 65 64 01 00 09 53 69 67 6E 61 74 75 72 65 01 00 05 28 29 54 54 " +
-          "3B 01 00 19 52 75 6E 74 69 6D 65 56 69 73 69 62 6C 65 41 6E 6E 6F " +
-          "74 61 74 69 6F 6E 73 01 00 16 4C 6A 61 76 61 2F 6C 61 6E 67 2F 44 " +
-          "65 70 72 65 63 61 74 65 64 3B 01 00 28 3C 54 3A 4C 6A 61 76 61 2F " +
-          "6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 3E 4C 6A 61 76 61 2F 6C 61 6E " +
-          "67 2F 4F 62 6A 65 63 74 3B 01 00 0A 53 6F 75 72 63 65 46 69 6C 65 " +
-          "01 00 12 41 74 74 72 69 62 75 74 65 54 65 73 74 2E 6A 61 76 61 0C " +
-          "00 0F 00 10 01 00 18 41 74 74 72 69 62 75 74 65 54 65 73 74 24 49 " +
-          "6E 6E 65 72 43 6C 61 73 73 0C 00 0F 00 25 01 00 0D 41 74 74 72 69 " +
-          "62 75 74 65 54 65 73 74 0C 00 26 00 0C 01 00 13 6A 61 76 61 2F 69 " +
-          "6F 2F 49 4F 45 78 63 65 70 74 69 6F 6E 01 00 10 6A 61 76 61 2F 6C " +
-          "61 6E 67 2F 4F 62 6A 65 63 74 01 00 12 28 4C 41 74 74 72 69 62 75 " +
-          "74 65 54 65 73 74 3B 29 56 01 00 0A 69 6E 6E 65 72 46 69 65 6C 64 " +
-          "00 21 00 04 00 08 00 00 00 01 00 19 00 0B 00 0C 00 01 00 0D 00 00 " +
-          "00 02 00 0E 00 02 00 01 00 0F 00 10 00 01 00 11 00 00 00 1D 00 01 " +
-          "00 01 00 00 00 05 2A B7 00 01 B1 00 00 00 01 00 12 00 00 00 06 00 " +
-          "01 00 00 00 03 00 01 00 13 00 14 00 05 00 11 00 00 00 37 00 03 00 " +
-          "02 00 00 00 17 BB 00 02 59 2A B7 00 03 4C 2B 10 2A B5 00 05 BB 00 " +
-          "06 59 B7 00 07 BF 00 00 00 01 00 12 00 00 00 0E 00 03 00 00 00 0C " +
-          "00 09 00 0D 00 0F 00 0E 00 15 00 00 00 04 00 01 00 06 00 16 00 00 " +
-          "00 00 00 17 00 00 00 02 00 18 00 19 00 00 00 06 00 01 00 1A 00 00 " +
-          "00 03 00 17 00 00 00 02 00 1B 00 1C 00 00 00 02 00 1D 00 0A 00 00 " +
-          "00 0A 00 01 00 02 00 04 00 09 00 01")
+        val classFile = hex"""
+          CA FE BA BE
+          00 00 00 34 00 27 0A 00 08 00 1E 07 00 1F 0A 00 02 00 20 07 00 21
+          09 00 02 00 22 07 00 23 0A 00 06 00 1E 07 00 24 01 00 0A 49 6E 6E
+          65 72 43 6C 61 73 73 01 00 0C 49 6E 6E 65 72 43 6C 61 73 73 65 73
+          01 00 09 43 4F 4E 53 54 5F 56 41 4C 01 00 01 49 01 00 0D 43 6F 6E
+          73 74 61 6E 74 56 61 6C 75 65 03 00 00 00 2A 01 00 06 3C 69 6E 69
+          74 3E 01 00 03 28 29 56 01 00 04 43 6F 64 65 01 00 0F 4C 69 6E 65
+          4E 75 6D 62 65 72 54 61 62 6C 65 01 00 06 6D 65 74 68 6F 64 01 00
+          14 28 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 01
+          00 0A 45 78 63 65 70 74 69 6F 6E 73 01 00 0A 44 65 70 72 65 63 61
+          74 65 64 01 00 09 53 69 67 6E 61 74 75 72 65 01 00 05 28 29 54 54
+          3B 01 00 19 52 75 6E 74 69 6D 65 56 69 73 69 62 6C 65 41 6E 6E 6F
+          74 61 74 69 6F 6E 73 01 00 16 4C 6A 61 76 61 2F 6C 61 6E 67 2F 44
+          65 70 72 65 63 61 74 65 64 3B 01 00 28 3C 54 3A 4C 6A 61 76 61 2F
+          6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 3E 4C 6A 61 76 61 2F 6C 61 6E
+          67 2F 4F 62 6A 65 63 74 3B 01 00 0A 53 6F 75 72 63 65 46 69 6C 65
+          01 00 12 41 74 74 72 69 62 75 74 65 54 65 73 74 2E 6A 61 76 61 0C
+          00 0F 00 10 01 00 18 41 74 74 72 69 62 75 74 65 54 65 73 74 24 49
+          6E 6E 65 72 43 6C 61 73 73 0C 00 0F 00 25 01 00 0D 41 74 74 72 69
+          62 75 74 65 54 65 73 74 0C 00 26 00 0C 01 00 13 6A 61 76 61 2F 69
+          6F 2F 49 4F 45 78 63 65 70 74 69 6F 6E 01 00 10 6A 61 76 61 2F 6C
+          61 6E 67 2F 4F 62 6A 65 63 74 01 00 12 28 4C 41 74 74 72 69 62 75
+          74 65 54 65 73 74 3B 29 56 01 00 0A 69 6E 6E 65 72 46 69 65 6C 64
+          00 21 00 04 00 08 00 00 00 01 00 19 00 0B 00 0C 00 01 00 0D 00 00
+          00 02 00 0E 00 02 00 01 00 0F 00 10 00 01 00 11 00 00 00 1D 00 01
+          00 01 00 00 00 05 2A B7 00 01 B1 00 00 00 01 00 12 00 00 00 06 00
+          01 00 00 00 03 00 01 00 13 00 14 00 05 00 11 00 00 00 37 00 03 00
+          02 00 00 00 17 BB 00 02 59 2A B7 00 03 4C 2B 10 2A B5 00 05 BB 00
+          06 59 B7 00 07 BF 00 00 00 01 00 12 00 00 00 0E 00 03 00 00 00 0C
+          00 09 00 0D 00 0F 00 0E 00 15 00 00 00 04 00 01 00 06 00 16 00 00
+          00 00 00 17 00 00 00 02 00 18 00 19 00 00 00 06 00 01 00 1A 00 00
+          00 03 00 17 00 00 00 02 00 1B 00 1C 00 00 00 02 00 1D 00 0A 00 00
+          00 0A 00 01 00 02 00 04 00 09 00 01
+        """
         /* AttributeTest.class from compiled class AttributeTest.java */
 
 
@@ -643,19 +649,19 @@ object ClassTests extends TestSuite {
                   AThrow),
                 ArrayBuffer(),
                 ArrayBuffer(
-                  BasicAttribute("LineNumberTable", hexBytes("00 03 00 00 00 0c 00 09 00 0d 00 0f 00 0e"))
+                  BasicAttribute("LineNumberTable", hex"00 03 00 00 00 0c 00 09 00 0d 00 0f 00 0e")
                 )
               ),
               ExceptionsAttribute(ArrayBuffer(Class("java/io/IOException"))),
               DeprecatedAttribute,
               SignatureAttribute("()TT;"),
-              BasicAttribute("RuntimeVisibleAnnotations", hexBytes("00 01 00 1a 00 00"))
+              BasicAttribute("RuntimeVisibleAnnotations", hex"00 01 00 1a 00 00")
             )
           )
         )
       }
       'code {
-        val classFile = fastparse.byte.ByteVector(
+        val classFile = fastparse.byte.Bytes(
           ("yv66vgAAADQA2AoACgBoCQBpAGoIAGsKAGwAbQgAbggAbwoAbA" +
           "BwCABxCAByBwBzBwB0BkAJIftURC0YCgB1AHYKAGwAdwUAAAAAAAGGoARDaoAABkBe2ZmZmZmaB" +
           "kAFvwmVqveQBwB4CAB5CgAXAHoHAHsKABoAfAgAfQoAGgB6CAB+CAB/CACABwCBCACCCACDCACE" +
@@ -1507,7 +1513,7 @@ object ClassTests extends TestSuite {
 
         for(chunkSize <- Seq(1, 4, 16, 64, 256, 1024)){
           val Parsed.Success(parsedClassInfo, _) = ClassParse.classFile.parseIterator(
-            classFile.toArray.grouped(chunkSize).map(ByteVector.view)
+            classFile.toArray.grouped(chunkSize).map(Bytes.view)
           )
           val parsedClass = ClassParse.Ast.convertToAst(parsedClassInfo)
 

--- a/classparse/shared/src/test/scala/classparse/ClassTests.scala
+++ b/classparse/shared/src/test/scala/classparse/ClassTests.scala
@@ -157,7 +157,7 @@ object ClassTests extends TestSuite {
 
         for(chunkSize <- Seq(1, 4, 16, 64, 256, 1024)){
           val Parsed.Success(parsedClassInfo, _) = ClassParse.classFile.parseIterator(
-            classFile.grouped(chunkSize)
+            classFile.toArray.grouped(chunkSize).map(ByteVector.view)
           )
           val parsedClass = ClassParse.Ast.convertToAst(parsedClassInfo)
 
@@ -564,7 +564,7 @@ object ClassTests extends TestSuite {
 
         for(chunkSize <- Seq(1, 4, 16, 64, 256, 1024)){
           val Parsed.Success(parsedClassInfo, _) = ClassParse.classFile.parseIterator(
-            classFile.grouped(chunkSize)
+            classFile.toArray.grouped(chunkSize).map(ByteVector.view)
           )
           val parsedClass = ClassParse.Ast.convertToAst(parsedClassInfo)
 
@@ -655,7 +655,8 @@ object ClassTests extends TestSuite {
         )
       }
       'code {
-        val classFile = ("yv66vgAAADQA2AoACgBoCQBpAGoIAGsKAGwAbQgAbggAbwoAbA" +
+        val classFile = fastparse.byte.ByteVector(
+          ("yv66vgAAADQA2AoACgBoCQBpAGoIAGsKAGwAbQgAbggAbwoAbA" +
           "BwCABxCAByBwBzBwB0BkAJIftURC0YCgB1AHYKAGwAdwUAAAAAAAGGoARDaoAABkBe2ZmZmZmaB" +
           "kAFvwmVqveQBwB4CAB5CgAXAHoHAHsKABoAfAgAfQoAGgB6CAB+CAB/CACABwCBCACCCACDCACE" +
           "CACFBwCGCgAmAGgIAIcKACYAiAoAJgCJCgAmAIoIAIsIAIwIAI0IAI4IAI8IAJAKACYAkQgAkgg" +
@@ -727,7 +728,7 @@ object ClassTests extends TestSuite {
           "cAYwcAZAcAZQcAYwcAZAcAZQEBAQEAABEH/AACART8ABwB/AAuAfoAFPwAAgH8AAkBFfoABfoAB" +
           "f8APAAlBwBfAQEBAQEBBAIDAQEBAAMHAGAHAGEHAGEHAGIHAGIHAGIHAGMHAGQHAGUHAGMHAGQH" +
           "AGUBAQEBAQEHAGMHAGMBAQAA+AAb/AAdAQYGBvwAAwcAYv4ASgcAYgcAYgEPDwwaCgoK+QAZ/AA" +
-          "OAUEHAGIAAQBmAAAAAgBn").toByteArray
+          "OAUEHAGIAAQBmAAAAAgBn").toByteArray)
         /* CodeTest.class from compiled class CodeTest.java */
 
         val expectedPool = ArrayBuffer(
@@ -1505,7 +1506,9 @@ object ClassTests extends TestSuite {
         )
 
         for(chunkSize <- Seq(1, 4, 16, 64, 256, 1024)){
-          val Parsed.Success(parsedClassInfo, _) = ClassParse.classFile.parseIterator(classFile.grouped(chunkSize))
+          val Parsed.Success(parsedClassInfo, _) = ClassParse.classFile.parseIterator(
+            classFile.toArray.grouped(chunkSize).map(ByteVector.view)
+          )
           val parsedClass = ClassParse.Ast.convertToAst(parsedClassInfo)
 
           assert(parsedClass.pool == expectedPool)

--- a/classparse/shared/src/test/scala/classparse/TestUtils.scala
+++ b/classparse/shared/src/test/scala/classparse/TestUtils.scala
@@ -1,6 +1,5 @@
 package classparse
 
-import classparse.ClassParse
 import fastparse.byte._
 import utest._
 
@@ -16,7 +15,7 @@ object TestUtils {
     }
   }
 
-  def checkClassAndClassFile(javaClass: Class[_], classFile: Array[Byte]) = {
+  def checkClassAndClassFile(javaClass: Class[_], classFile: ByteVector) = {
     val classInfo = ClassParse.classFile.parse(classFile) match {
       case Parsed.Success(info, _) => Some(info)
       case f: Parsed.Failure => None

--- a/classparse/shared/src/test/scala/classparse/TestUtils.scala
+++ b/classparse/shared/src/test/scala/classparse/TestUtils.scala
@@ -15,7 +15,7 @@ object TestUtils {
     }
   }
 
-  def checkClassAndClassFile(javaClass: Class[_], classFile: ByteVector) = {
+  def checkClassAndClassFile(javaClass: Class[_], classFile: Bytes) = {
     val classInfo = ClassParse.classFile.parse(classFile) match {
       case Parsed.Success(info, _) => Some(info)
       case f: Parsed.Failure => None

--- a/demo/src/main/scala/demo/DemoMain.scala
+++ b/demo/src/main/scala/demo/DemoMain.scala
@@ -61,7 +61,9 @@ object DemoMain {
       reader.readAsArrayBuffer(uploadFile.files.item(0))
       reader.onload = (e: UIEvent) => {
         val array = new Uint8Array(reader.result.asInstanceOf[ArrayBuffer])
-        val contents = (for (i <- 0 until array.length) yield array.get(i).toByte).toArray
+        val contents = fastparse.byte.ByteVector.view(
+          (for (i <- 0 until array.length) yield array.get(i).toByte).toArray
+        )
         dom.console.log(contents.length)
         fastparse.MidiParse.midiParser.parse(contents) match{
           case Parsed.Success(midi, index) =>
@@ -325,7 +327,7 @@ object DemoMain {
     container.appendChild(div(inputBox, outputBox, div(clear.both)).render)
   }
 
-  def helperByteFile(container: html.Div, parser: Parser[_, Byte, Array[Byte]]) = {
+  def helperByteFile(container: html.Div, parser: Parser[_, Byte, fastparse.byte.ByteVector]) = {
     import scalatags.JsDom.all._
     val uploadFile = input(
       width := "30%",
@@ -342,7 +344,9 @@ object DemoMain {
       reader.readAsArrayBuffer(uploadFile.files.item(0))
       reader.onload = (e: UIEvent) => {
         val array = new Uint8Array(reader.result.asInstanceOf[ArrayBuffer])
-        val contents = (for (i <- 0 until array.length) yield array.get(i).toByte).toArray
+        val contents = fastparse.byte.ByteVector.view(
+          (for (i <- 0 until array.length) yield array.get(i).toByte).toArray
+        )
 
         val details = parser.parse(contents) match {
           case s: Parsed.Success[_, Byte] =>

--- a/demo/src/main/scala/demo/DemoMain.scala
+++ b/demo/src/main/scala/demo/DemoMain.scala
@@ -61,7 +61,7 @@ object DemoMain {
       reader.readAsArrayBuffer(uploadFile.files.item(0))
       reader.onload = (e: UIEvent) => {
         val array = new Uint8Array(reader.result.asInstanceOf[ArrayBuffer])
-        val contents = fastparse.byte.ByteVector.view(
+        val contents = fastparse.byte.Bytes.view(
           (for (i <- 0 until array.length) yield array.get(i).toByte).toArray
         )
         dom.console.log(contents.length)
@@ -327,7 +327,7 @@ object DemoMain {
     container.appendChild(div(inputBox, outputBox, div(clear.both)).render)
   }
 
-  def helperByteFile(container: html.Div, parser: Parser[_, Byte, fastparse.byte.ByteVector]) = {
+  def helperByteFile(container: html.Div, parser: Parser[_, Byte, fastparse.byte.Bytes]) = {
     import scalatags.JsDom.all._
     val uploadFile = input(
       width := "30%",
@@ -344,7 +344,7 @@ object DemoMain {
       reader.readAsArrayBuffer(uploadFile.files.item(0))
       reader.onload = (e: UIEvent) => {
         val array = new Uint8Array(reader.result.asInstanceOf[ArrayBuffer])
-        val contents = fastparse.byte.ByteVector.view(
+        val contents = fastparse.byte.Bytes.view(
           (for (i <- 0 until array.length) yield array.get(i).toByte).toArray
         )
 

--- a/fastparse/jvm/src/test/scala/fastparse/LargeBmpIteratorTests.scala
+++ b/fastparse/jvm/src/test/scala/fastparse/LargeBmpIteratorTests.scala
@@ -2,7 +2,6 @@ package fastparse
 
 import java.io.InputStream
 
-import scodec.bits.ByteVector
 import utest._
 import fastparse.byte._
 import fastparse.BmpTests.BmpParse._
@@ -10,7 +9,7 @@ import fastparse.BmpTests.BmpParse._
 import scala.collection.mutable
 object LargeBmpIteratorTests extends TestSuite {
 
-  class StreamToIteratorByte(stream: InputStream, bufferSize: Int) extends Iterator[ByteVector] {
+  class StreamToIteratorByte(stream: InputStream, bufferSize: Int) extends Iterator[Bytes] {
     val buffer = new Array[Byte](bufferSize)
     var bufferLen = 0
     var isRead = false
@@ -28,11 +27,11 @@ object LargeBmpIteratorTests extends TestSuite {
         bufferLen != -1
       }
 
-    override def next(): ByteVector = {
+    override def next(): Bytes = {
       if (!isRead)
         readBuffer()
       isRead = false
-      ByteVector.view(buffer.take(bufferLen))
+      Bytes.view(buffer.take(bufferLen))
     }
   }
 

--- a/fastparse/jvm/src/test/scala/fastparse/LargeBmpIteratorTests.scala
+++ b/fastparse/jvm/src/test/scala/fastparse/LargeBmpIteratorTests.scala
@@ -2,7 +2,7 @@ package fastparse
 
 import java.io.InputStream
 
-
+import scodec.bits.ByteVector
 import utest._
 import fastparse.byte._
 import fastparse.BmpTests.BmpParse._
@@ -10,7 +10,7 @@ import fastparse.BmpTests.BmpParse._
 import scala.collection.mutable
 object LargeBmpIteratorTests extends TestSuite {
 
-  class StreamToIteratorByte(stream: InputStream, bufferSize: Int) extends Iterator[Array[Byte]] {
+  class StreamToIteratorByte(stream: InputStream, bufferSize: Int) extends Iterator[ByteVector] {
     val buffer = new Array[Byte](bufferSize)
     var bufferLen = 0
     var isRead = false
@@ -28,11 +28,11 @@ object LargeBmpIteratorTests extends TestSuite {
         bufferLen != -1
       }
 
-    override def next(): Array[Byte] = {
+    override def next(): ByteVector = {
       if (!isRead)
         readBuffer()
       isRead = false
-      buffer.take(bufferLen)
+      ByteVector.view(buffer.take(bufferLen))
     }
   }
 
@@ -46,7 +46,7 @@ object LargeBmpIteratorTests extends TestSuite {
     }
 
     'maxInnerLength {
-      val loggedInput = new IteratorParserInput[Byte](lenaIterator.map(wrapByteArray)) {
+      val loggedInput = new IteratorParserInput[Byte](lenaIterator.map(_.toArray)) {
         var maxInnerLength = 0
 
         override def dropBuffer(index: Int): Unit = {

--- a/fastparse/jvm/src/test/scala/fastparse/LargeBmpTests.scala
+++ b/fastparse/jvm/src/test/scala/fastparse/LargeBmpTests.scala
@@ -3,7 +3,6 @@ import java.awt.Color
 import java.awt.image.BufferedImage
 import java.nio.file.{Files, Paths}
 import javax.imageio.ImageIO
-import scodec.bits.ByteVector
 import utest._
 import fastparse.byte._
 
@@ -15,7 +14,7 @@ object LargeBmpTests extends TestSuite {
     'lena {
       val lenaRecource = getClass.getResource("/lena.bmp")
       val Parsed.Success(lenaBmp, _) = bmp.parse(
-        ByteVector(Files.readAllBytes(Paths.get(lenaRecource.toURI.getPath)))
+        Bytes(Files.readAllBytes(Paths.get(lenaRecource.toURI.getPath)))
       )
 
       def compareBmpImg(bmp: Bmp, img: BufferedImage): Unit = {

--- a/fastparse/jvm/src/test/scala/fastparse/LargeBmpTests.scala
+++ b/fastparse/jvm/src/test/scala/fastparse/LargeBmpTests.scala
@@ -1,10 +1,9 @@
 package fastparse
-
 import java.awt.Color
 import java.awt.image.BufferedImage
 import java.nio.file.{Files, Paths}
 import javax.imageio.ImageIO
-
+import scodec.bits.ByteVector
 import utest._
 import fastparse.byte._
 
@@ -15,7 +14,9 @@ object LargeBmpTests extends TestSuite {
   val tests = TestSuite {
     'lena {
       val lenaRecource = getClass.getResource("/lena.bmp")
-      val Parsed.Success(lenaBmp, _) = bmp.parse(Files.readAllBytes(Paths.get(lenaRecource.toURI.getPath)))
+      val Parsed.Success(lenaBmp, _) = bmp.parse(
+        ByteVector(Files.readAllBytes(Paths.get(lenaRecource.toURI.getPath)))
+      )
 
       def compareBmpImg(bmp: Bmp, img: BufferedImage): Unit = {
         assert(bmp.pixels.length == img.getHeight)

--- a/fastparse/jvm/src/test/scala/fastparse/MidiTests.scala
+++ b/fastparse/jvm/src/test/scala/fastparse/MidiTests.scala
@@ -2,22 +2,21 @@ package fastparse
 
 import java.nio.file.{Files, Paths}
 
-import scodec.bits.ByteVector
 import utest._
-
+import fastparse.byte.Bytes
 
 object MidiTests extends TestSuite{
   def readResourceBytes(file: String) = {
-    ByteVector(Files.readAllBytes(Paths.get(getClass.getResource(file).toURI.getPath)))
+    Bytes(Files.readAllBytes(Paths.get(getClass.getResource(file).toURI.getPath)))
   }
 
 
 
-  def variousParses(bytes: ByteVector) = {
+  def variousParses(bytes: Bytes) = {
     val stringParse = MidiParse.midiParser.parse(bytes).get.value
     val iteratorParses =
       for(i <- Seq(1, 4, 16, 64, 256, 1024))
-      yield MidiParse.midiParser.parseIterator(bytes.toArray.grouped(i).map(ByteVector.view)).get.value
+      yield MidiParse.midiParser.parseIterator(bytes.toArray.grouped(i).map(Bytes.view)).get.value
 
     stringParse +: iteratorParses
   }

--- a/fastparse/jvm/src/test/scala/fastparse/MidiTests.scala
+++ b/fastparse/jvm/src/test/scala/fastparse/MidiTests.scala
@@ -47,7 +47,6 @@ object MidiTests extends TestSuite{
           parsed.tracks(1).length == 293
         )
 
-        parsed.tracks(1).foreach(println)
       }
     }
     'chronoTrigger{
@@ -73,7 +72,6 @@ object MidiTests extends TestSuite{
           parsed.tracks(0)(0)._2.isInstanceOf[SysExEvent.Message],
           parsed.tracks(0).drop(1) == expectedTrack0
         )
-        parsed.tracks(0).foreach(println)
         assert()
 
       }

--- a/fastparse/jvm/src/test/scala/fastparse/MidiTests.scala
+++ b/fastparse/jvm/src/test/scala/fastparse/MidiTests.scala
@@ -2,21 +2,22 @@ package fastparse
 
 import java.nio.file.{Files, Paths}
 
+import scodec.bits.ByteVector
 import utest._
 
 
 object MidiTests extends TestSuite{
   def readResourceBytes(file: String) = {
-    Files.readAllBytes(Paths.get(getClass.getResource(file).toURI.getPath))
+    ByteVector(Files.readAllBytes(Paths.get(getClass.getResource(file).toURI.getPath)))
   }
 
 
 
-  def variousParses(bytes: Array[Byte]) = {
+  def variousParses(bytes: ByteVector) = {
     val stringParse = MidiParse.midiParser.parse(bytes).get.value
     val iteratorParses =
       for(i <- Seq(1, 4, 16, 64, 256, 1024))
-      yield MidiParse.midiParser.parseIterator(bytes.grouped(i)).get.value
+      yield MidiParse.midiParser.parseIterator(bytes.toArray.grouped(i).map(ByteVector.view)).get.value
 
     stringParse +: iteratorParses
   }

--- a/fastparse/shared/src/main/scala/fastparse/Api.scala
+++ b/fastparse/shared/src/main/scala/fastparse/Api.scala
@@ -98,51 +98,50 @@ class ByteApi() extends Api[Byte, ByteVector]() {
   def ElemIn(strings: Seq[Byte]*) = ByteIn(strings:_*)
   def ElemsWhile(pred: Byte => Boolean, min: Int = 1) = BytesWhile(pred, min)
 
+  /**
+    * Construct a literal byte-parser out of raw byte values. Any integral
+    * values can be used, but they will be truncated down to `Byte`s before
+    * being used in the parser
+    */
   def BS[T](bytes: T*)(implicit num: Integral[T]): P0 = {
     parsers.Terminals.Literal[Byte, Bytes](bytes.map(num.toInt(_).toByte).toArray[Byte])
   }
+
+  /**
+    * Construct a literal byte-parser out of an immutable `Bytes` value
+    */
   def BS[T](bytes: Bytes): P0 = {
     parsers.Terminals.Literal[Byte, Bytes](bytes.toArray)
   }
 
+  /**
+    * Convenient, more-concise alias for `scodec.bits.ByteVector`
+    */
   val Bytes = scodec.bits.ByteVector
   type Bytes = scodec.bits.ByteVector
 
   implicit def HexStringSyntax(sc: StringContext) = new scodec.bits.HexStringSyntax(sc)
 
-  object HexBytesParser {
-    import all._
-
-    val hexChars = HexUtils.hexChars
-
-    def charsToByte(s: String): Byte = {
-      (hexChars.indexOf(s(1)) + hexChars.indexOf(s(0)) * 16).toByte
-    }
-
-    val hexDigit = all.P(CharIn('0' to '9', 'a' to 'f', 'A' to 'F'))
-    val byte = all.P(hexDigit.rep(exactly = 2))
-    val whitespace = " \n\r".toSet
-    val byteSep = all.P(CharsWhile(whitespace, min = 0))
-    val bytes = all.P(byteSep ~ byte.rep(sep = byteSep)).!.map(Bytes.fromHex(_))
-  }
-
-
-
-  type GenericIntegerParser[T] = ByteUtils.GenericIntegerParser[T]
+  /**
+    * Little-endian integer parsers
+    */
   val LE = ByteUtils.EndianByteParsers.LE
+  /**
+    * Big-endian integer parsers
+    */
   val BE = ByteUtils.EndianByteParsers.BE
   /**
     * Parses a two-byte word
     */
-  val Word16: P[Unit] = new GenericIntegerParser(2, (input, n) => ())
+  val Word16: P[Unit] = new ByteUtils.GenericIntegerParser[T](2, (input, n) => ())
   /**
     * Parses a four-byte word
     */
-  val Word32: P[Unit] = new GenericIntegerParser(4, (input, n) => ())
+  val Word32: P[Unit] = new ByteUtils.GenericIntegerParser[T](4, (input, n) => ())
   /**
     * Parses an eight-byte word
     */
-  val Word64: P[Unit] = new GenericIntegerParser(8, (input, n) => ())
+  val Word64: P[Unit] = new ByteUtils.GenericIntegerParser[T](8, (input, n) => ())
 
   val Int8 = ByteUtils.Int8
 

--- a/fastparse/shared/src/main/scala/fastparse/Api.scala
+++ b/fastparse/shared/src/main/scala/fastparse/Api.scala
@@ -133,15 +133,15 @@ class ByteApi() extends Api[Byte, ByteVector]() {
   /**
     * Parses a two-byte word
     */
-  val Word16: P[Unit] = new ByteUtils.GenericIntegerParser[T](2, (input, n) => ())
+  val Word16: P[Unit] = new ByteUtils.GenericIntegerParser[Unit](2, (input, n) => ())
   /**
     * Parses a four-byte word
     */
-  val Word32: P[Unit] = new ByteUtils.GenericIntegerParser[T](4, (input, n) => ())
+  val Word32: P[Unit] = new ByteUtils.GenericIntegerParser[Unit](4, (input, n) => ())
   /**
     * Parses an eight-byte word
     */
-  val Word64: P[Unit] = new ByteUtils.GenericIntegerParser[T](8, (input, n) => ())
+  val Word64: P[Unit] = new ByteUtils.GenericIntegerParser[Unit](8, (input, n) => ())
 
   val Int8 = ByteUtils.Int8
 

--- a/fastparse/shared/src/main/scala/fastparse/Api.scala
+++ b/fastparse/shared/src/main/scala/fastparse/Api.scala
@@ -102,7 +102,8 @@ class ByteApi() extends Api[Byte, ByteVector]() {
     ByteVector(bytes:_*)
   }
 
-
+  val ByteVector = scodec.bits.ByteVector
+  type ByteVector = scodec.bits.ByteVector
   implicit def wspByteSeq(seq: ByteVector): P0 =
     if (seq.length == 1) parsers.Terminals.ElemLiteral[Byte, ByteVector](seq(0))
     else parsers.Terminals.Literal[Byte, ByteVector](seq.toArray)

--- a/fastparse/shared/src/main/scala/fastparse/Api.scala
+++ b/fastparse/shared/src/main/scala/fastparse/Api.scala
@@ -126,14 +126,14 @@ class ByteApi() extends Api[Byte, ByteVector]() {
 
 
   /**
-    * Helper method to convert a space-separated string of hexidecimal bytes
-    * (e.g. "01 bc 21 04") into the corresponding ByteVector
+    * Shorthand for ByteVector.fromHex
     */
-  def hexBytes(s: String): ByteVector = {
-    HexBytesParser.bytes.parse(s).get.value.getOrElse(
-      throw new Exception("Invalid hexBytes contents: " + s)
-    )
-  }
+  def hexBytes(s: String): ByteVector = ByteVector.fromHex(s).get
+
+  /**
+    * Shorthand for ByteVector.apply
+    */
+  val bytes = ByteVector
 
 
   type GenericIntegerParser[T] = ByteUtils.GenericIntegerParser[T]

--- a/fastparse/shared/src/main/scala/fastparse/ByteUtils.scala
+++ b/fastparse/shared/src/main/scala/fastparse/ByteUtils.scala
@@ -55,7 +55,7 @@ object ByteUtils{
       val endRow = grouped.last / 16 + contextRows
       for{
         i <- startRow to endRow
-        sliced = bytes.slice(i * 16, (i + 1) * 16)
+        sliced = bytes.slice(math.max(0, i * 16), math.max(0, (i + 1) * 16))
         if sliced.nonEmpty
       }{
 

--- a/fastparse/shared/src/main/scala/fastparse/ByteUtils.scala
+++ b/fastparse/shared/src/main/scala/fastparse/ByteUtils.scala
@@ -1,5 +1,5 @@
 package fastparse
-
+import scodec.bits.ByteVector
 import fastparse.Utils.IsReachable
 import fastparse.core.ParseCtx
 
@@ -10,7 +10,7 @@ import scala.collection.mutable
   * and not FastParse as a whole.
   */
 object ByteUtils{
-  def prettyBytes(bytes: Array[Byte],
+  def prettyBytes(bytes: ByteVector,
                   markers: Seq[Int] = Seq(-1),
                   contextRows: Int = 8) = {
     val invalidIndices = markers.filter(
@@ -26,7 +26,12 @@ object ByteUtils{
     val output = new StringBuffer
     val emptyGutter = " " * (maxIndexWidth + gutter)
     output.append(emptyGutter)
-    output.append(0.until(math.min(16, bytes.length)).map(x => x.toString.padTo(2, ' ')).mkString(" ").trim)
+    output.append(
+      0.until(math.min(16, bytes.length.toInt))
+        .map(x => x.toString.padTo(2, ' '))
+        .mkString(" ")
+        .trim
+    )
     output.append('\n')
 
     val sortedIndices = markers.sorted
@@ -54,7 +59,7 @@ object ByteUtils{
         if sliced.nonEmpty
       }{
 
-        val prettyRow = ElemTypeFormatter.ByteFormatter.prettyPrint(sliced)
+        val prettyRow = ElemTypeFormatter.ByteFormatter.prettyPrint(sliced.toArray)
         output.append('\n')
         output.append((i * 16).toString.padTo(maxIndexWidth + gutter, ' '))
         output.append(prettyRow)
@@ -80,7 +85,7 @@ object ByteUtils{
 
     output.toString
   }
-  private[this] type Parser[+T] = fastparse.core.Parser[T, Byte, Array[Byte]]
+  private[this] type Parser[+T] = fastparse.core.Parser[T, Byte, ByteVector]
 
 
 
@@ -89,7 +94,7 @@ object ByteUtils{
 
     override def toString = name.value
 
-    def parseRec(cfg: ParseCtx[Byte, Array[Byte]], index: Int) = {
+    def parseRec(cfg: ParseCtx[Byte,ByteVector], index: Int) = {
       if (!cfg.input.isReachable(n + index - 1)) fail(cfg.failure, index)
       else success(cfg.success, creator(cfg.input, index), index + n, Set.empty, false)
 

--- a/fastparse/shared/src/test/scala/fastparse/BmpTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/BmpTests.scala
@@ -2,7 +2,6 @@ package fastparse
 
 import scala.collection.mutable.ArrayBuffer
 import fastparse.byte._
-import scodec.bits.ByteVector
 import utest._
 
 /*
@@ -30,7 +29,7 @@ object BmpTests extends TestSuite {
 
       case class BitmapInfoHeader(infoPart: BitmapInfoHeaderPart) extends BitmapHeader(infoPart)
 
-      case class Pixel(colors: ByteVector)
+      case class Pixel(colors: Bytes)
 
       case class Bmp(fileHeader: FileHeader, bitmapHeader: BitmapHeader, pixels: Seq[Seq[Pixel]])
 
@@ -135,11 +134,11 @@ object BmpTests extends TestSuite {
           FileHeader(19778, 70, 54),
           BitmapInfoHeader(BitmapInfoHeaderPart(2, 2, 1, 24, 0, 16, 2835, 2835, 0, 0)),
           ArrayBuffer(ArrayBuffer(
-            Pixel(ByteVector(0xff, 0, 0)),
-            Pixel(ByteVector(0, 0xff, 0))),
+            Pixel(Bytes(0xff, 0, 0)),
+            Pixel(Bytes(0, 0xff, 0))),
             ArrayBuffer(
-              Pixel(ByteVector(0, 0, 0xff)),
-              Pixel(ByteVector(0xff, 0xff, 0xff))
+              Pixel(Bytes(0, 0, 0xff)),
+              Pixel(Bytes(0xff, 0xff, 0xff))
             )
           )
         )
@@ -149,7 +148,7 @@ object BmpTests extends TestSuite {
 
         for(chunkSize <- Seq(1, 4, 16, 64, 256, 1024)){
           val Parsed.Success(bmp1, _) = bmp.parseIterator(
-            file1.toArray.grouped(chunkSize).map(ByteVector.view)
+            file1.toArray.grouped(chunkSize).map(Bytes.view)
           )
           assert(compareBmps(bmp1, expected))
         }
@@ -171,15 +170,15 @@ object BmpTests extends TestSuite {
         val expected = Bmp(FileHeader(19778, 154, 122),
           BitmapInfoHeader(BitmapInfoHeaderPart(4, 2, 1, 32, 3, 32, 2835, 2835, 0, 0)),
           ArrayBuffer(ArrayBuffer(
-            Pixel(ByteVector(0xff, 0, 0, 0xff)),
-            Pixel(ByteVector(0, 0xff, 0, 0xff)),
-            Pixel(ByteVector(0, 0, 0xff, 0xff)),
-            Pixel(ByteVector(0xff, 0xff, 0xff, 0xff))),
+            Pixel(Bytes(0xff, 0, 0, 0xff)),
+            Pixel(Bytes(0, 0xff, 0, 0xff)),
+            Pixel(Bytes(0, 0, 0xff, 0xff)),
+            Pixel(Bytes(0xff, 0xff, 0xff, 0xff))),
             ArrayBuffer(
-              Pixel(ByteVector(0xff, 0, 0, 0x7f)),
-              Pixel(ByteVector(0, 0xff, 0, 0x7f)),
-              Pixel(ByteVector(0, 0, 0xff, 0x7f)),
-              Pixel(ByteVector(0, 0, 0xff, 0x7f))
+              Pixel(Bytes(0xff, 0, 0, 0x7f)),
+              Pixel(Bytes(0, 0xff, 0, 0x7f)),
+              Pixel(Bytes(0, 0, 0xff, 0x7f)),
+              Pixel(Bytes(0, 0, 0xff, 0x7f))
             )
           )
         )
@@ -189,7 +188,7 @@ object BmpTests extends TestSuite {
 
         for(chunkSize <- Seq(1, 4, 16, 64, 256, 1024)){
           val Parsed.Success(bmp2, _) = bmp.parseIterator(
-            file1.toArray.grouped(chunkSize).map(ByteVector.view)
+            file1.toArray.grouped(chunkSize).map(Bytes.view)
           )
           assert(compareBmps(bmp2, expected))
         }

--- a/fastparse/shared/src/test/scala/fastparse/BmpTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/BmpTests.scala
@@ -122,12 +122,12 @@ object BmpTests extends TestSuite {
     'wiki {
       /* These tests were taken from wiki page https://en.wikipedia.org/wiki/BMP_file_format */
       'example1 {
-        val file1 = hexBytes(
-          /*file header*/ "42 4d  46 00 00 00  00 00  00 00  36 00 00 00 " +
-            /*bitmap header*/ "28 00 00 00  02 00 00 00  02 00 00 00  01 00  18 00  " +
-            "00 00 00 00  10 00 00 00  13 0b 00 00  13 0b 00 00  " +
-            "00 00 00 00  00 00 00 00" +
-            /*pixels*/  "00 00 ff  ff ff ff  00 00  ff 00 00  00 ff 00  00 00")
+        val file1 =
+          /*file header*/ hex"42 4d  46 00 00 00  00 00  00 00  36 00 00 00 " ++
+          /*bitmap header*/ hex"28 00 00 00  02 00 00 00  02 00 00 00  01 00  18 00  " ++
+          hex"00 00 00 00  10 00 00 00  13 0b 00 00  13 0b 00 00  " ++
+          hex"00 00 00 00  00 00 00 00" ++
+          /*pixels*/  hex"00 00 ff  ff ff ff  00 00  ff 00 00  00 ff 00  00 00"
 
 
 
@@ -156,15 +156,16 @@ object BmpTests extends TestSuite {
       }
 
       'example2 {
-        val file1 = hexBytes(
-          /*file header*/ "42 4d  9A 00 00 00  00 00  00 00  7A 00 00 00 " +
-            /*bitmap header*/ "6C 00 00 00  04 00 00 00  02 00 00 00  01 00  20 00  " +
-            "03 00 00 00  20 00 00 00  13 0B 00 00  13 0B 00 00 " +
-            "00 00 00 00  00 00 00 00  00 00 FF 00  00 FF 00 00 " +
-            "FF 00 00 00  00 00 00 FF  20 6E 69 57 " + "00" * 36 +
-            "00 00 00 00  00 00 00 00  00 00 00 00" +
-            /*pixels*/  "FF 00 00 7F  00 FF 00 7F  00 00 FF 7F  00 00 FF 7F " +
-            "FF 00 00 FF  00 FF 00 FF  00 00 FF FF  FF FF FF FF")
+
+        val file1 =
+          /*file header*/ hex"42 4d  9A 00 00 00  00 00  00 00  7A 00 00 00 " ++
+          /*bitmap header*/ hex"6C 00 00 00  04 00 00 00  02 00 00 00  01 00  20 00  " ++
+          hex"03 00 00 00  20 00 00 00  13 0B 00 00  13 0B 00 00 " ++
+          hex"00 00 00 00  00 00 00 00  00 00 FF 00  00 FF 00 00 " ++
+          hex"FF 00 00 00  00 00 00 FF  20 6E 69 57 " ++ Bytes.fill(36)(0) ++
+          hex"00 00 00 00  00 00 00 00  00 00 00 00" ++
+          /*pixels*/  hex"FF 00 00 7F  00 FF 00 7F  00 00 FF 7F  00 00 FF 7F " ++
+          hex"FF 00 00 FF  00 FF 00 FF  00 00 FF FF  FF FF FF FF"
 
 
         val expected = Bmp(FileHeader(19778, 154, 122),

--- a/fastparse/shared/src/test/scala/fastparse/ByteTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ByteTests.scala
@@ -345,43 +345,45 @@ object ByteTests extends TestSuite {
 
 
         }
-      }
-      'bytes{
-        'construction{
+        'hexBytes{
           import fastparse.byte._
 
-          // Constructing a short ByteVector from bytes
-          val a = Bytes(0x01, 0xff)
-          assert(a.toString == "ByteVector(2 bytes, 0x01ff)")
+          // Constructing `Bytes` via their hex values
+          assert(
+            hex"01 ff" == Bytes(0x01, 0xff),
 
-          // Constructing a ByteVector from an ASCII string
-          val b  = Bytes("hello":_*)
-          assert(b.toString == "ByteVector(5 bytes, 0x68656c6c6f)")
+            hex"01 ff" == Bytes.fromHex("01 ff").get,
 
-          // Constructing a ByteVector copying from a Array[Byte]
-          val byteArray = Array[Byte](1, 2, 3, 4)
-          val c = Bytes(byteArray)
-          assert(c.toString == "ByteVector(4 bytes, 0x01020304)")
+            hex"""
+              de ad be ef
+              ca fe ba be
+            """ == Bytes(
+              0xde, 0xad, 0xbe, 0xef,
+              0xca, 0xfe, 0xba, 0xbe
+            ),
 
-          // Unsafe construction from an Array[Byte], without copying; assumes
-          // You do not mutate the underlying array, otherwise things break.
-          val d = Bytes.view(byteArray)
-          assert(d.toString == "ByteVector(4 bytes, 0x01020304)")
+            hex"""
+            de ad be ef
+            ca fe ba be
+            """ == Bytes.fromHex("""
+              de ad be ef
+              ca fe ba be
+            """).get
+          )
+
+
+          // You can interpolate Bytes into hex literals
+
+          val beef = hex"de ad be ef"
+          val cafeBytes = Bytes(0xca, 0xfe)
+          assert(
+            hex"$beef $cafeBytes ba be" == Bytes(
+              0xde, 0xad, 0xbe, 0xef,
+              0xca, 0xfe, 0xba, 0xbe
+            )
+          )
+
         }
-      }
-      'hexBytes{
-        import fastparse.byte._
-
-        assert(
-          hex"01 ff" == Bytes.fromHex("01 ff").get,
-          hex"""
-            de ad be ef
-            ca fe ba be
-          """ == Bytes.fromHex("""
-            de ad be ef
-            ca fe ba be
-          """).get
-        )
       }
       'prettyBytesBare{
         import fastparse.byte._

--- a/fastparse/shared/src/test/scala/fastparse/ByteTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ByteTests.scala
@@ -14,10 +14,10 @@ object ByteTests extends TestSuite {
         import fastparse.byte._
         val parseA = P(BS(1))
 
-        val Parsed.Success(value, successIndex) = parseA.parse(ByteVector(1))
+        val Parsed.Success(value, successIndex) = parseA.parse(Bytes(1))
         assert(value ==(), successIndex == 1)
 
-        val failure = parseA.parse(ByteVector(2)).asInstanceOf[Parsed.Failure]
+        val failure = parseA.parse(Bytes(2)).asInstanceOf[Parsed.Failure]
         assert(
           failure.lastParser == (BS(1): P0),
           failure.index == 0,
@@ -29,49 +29,49 @@ object ByteTests extends TestSuite {
         import fastparse.byte._
         val ab = P(BS(1) ~ BS(2)) // or P(Array[Byte](1) ~ Array[Byte](2))
 
-        val Parsed.Success(_, 2) = ab.parse(ByteVector(1, 2)) // BS(1, 2) == Array[Byte](1, 2)
+        val Parsed.Success(_, 2) = ab.parse(Bytes(1, 2)) // BS(1, 2) == Array[Byte](1, 2)
 
-        val Parsed.Failure(parser, 1, _) = ab.parse(hexBytes("01 01")) // or BS(1, 1)
+        val Parsed.Failure(parser, 1, _) = ab.parse(hex"01 01") // or BS(1, 1)
         assert(parser == (BS(2): P0))
       }
 
       'repeat {
         import fastparse.byte._
         val ab = P(BS(1).rep ~ BS(2))
-        val Parsed.Success(_, 8) = ab.parse(hexBytes("01 01 01 01 01 01 01 02"))
-        val Parsed.Success(_, 4) = ab.parse(hexBytes("01 01 01 02"))
+        val Parsed.Success(_, 8) = ab.parse(hex"01 01 01 01 01 01 01 02")
+        val Parsed.Success(_, 4) = ab.parse(hex"01 01 01 02")
 
         val abc = P(BS(1).rep(sep = BS(2)) ~ BS(3))
-        val Parsed.Success(_, 8) = abc.parse(hexBytes("01 02 01 02 01 02 01 03"))
-        val Parsed.Failure(parser, 3, _) = abc.parse(hexBytes("01 02 01 01 02 01 03"))
+        val Parsed.Success(_, 8) = abc.parse(hex"01 02 01 02 01 02 01 03")
+        val Parsed.Failure(parser, 3, _) = abc.parse(hex"01 02 01 01 02 01 03")
 
         val ab4 = P(BS(1).rep(min = 2, max = 4, sep = BS(2)))
-        val Parsed.Success(_, 7) = ab4.parse(hexBytes("01 02 01 02 01 02 01 02 01 02 01 02 01 02 01 02"))
+        val Parsed.Success(_, 7) = ab4.parse(hex"01 02 01 02 01 02 01 02 01 02 01 02 01 02 01 02")
 
         val ab4c = P(BS(1).rep(min = 2, max = 4, sep = BS(2)) ~ BS(3))
-        val Parsed.Failure(_, 1, _) = ab4c.parse(hexBytes("01 03"))
-        val Parsed.Success(_, 4) = ab4c.parse(hexBytes("01 02 01 03"))
-        val Parsed.Success(_, 8) = ab4c.parse(hexBytes("01 02 01 02 01 02 01 03"))
-        val Parsed.Failure(_, 7, _) = ab4c.parse(hexBytes("01 02 01 02 01 02 01 02 01 03"))
+        val Parsed.Failure(_, 1, _) = ab4c.parse(hex"01 03")
+        val Parsed.Success(_, 4) = ab4c.parse(hex"01 02 01 03")
+        val Parsed.Success(_, 8) = ab4c.parse(hex"01 02 01 02 01 02 01 03")
+        val Parsed.Failure(_, 7, _) = ab4c.parse(hex"01 02 01 02 01 02 01 02 01 03")
       }
 
       'option {
         import fastparse.byte._
         val option = P(BS(3).? ~ BS(1).rep(sep = BS(2)).! ~ End)
 
-        val Parsed.Success(res1, 3) = option.parse(hexBytes("01 02 01"))
-        assert(res1 == ByteVector(1, 2, 1))
+        val Parsed.Success(res1, 3) = option.parse(hex"01 02 01")
+        assert(res1 == Bytes(1, 2, 1))
 
-        val Parsed.Success(res2, 3) = option.parse(hexBytes("01 02 01"))
-        assert(res2 == ByteVector(1, 2, 1))
+        val Parsed.Success(res2, 3) = option.parse(hex"01 02 01")
+        assert(res2 == Bytes(1, 2, 1))
       }
 
       'either {
         import fastparse.byte._
         val either = P(BS(1).rep ~ (BS(2) | BS(3) | BS(4)) ~ End)
 
-        val Parsed.Success(_, 6) = either.parse(hexBytes("01 01 01 01 01 02"))
-        val Parsed.Failure(parser, 5, _) = either.parse(hexBytes("01 01 01 01 01 05"))
+        val Parsed.Success(_, 6) = either.parse(hex"01 01 01 01 01 02")
+        val Parsed.Failure(parser, 5, _) = either.parse(hex"01 01 01 01 01 05")
         assert(parser == (BS(2) | BS(3) | BS(4)))
       }
 
@@ -81,102 +81,102 @@ object ByteTests extends TestSuite {
         val noEnd = P(BS(1).rep ~ BS(2))
         val withEnd = P(BS(1).rep ~ BS(2) ~ End)
 
-        val Parsed.Success(_, 4) = noEnd.parse(hexBytes("01 01 01 02 01"))
-        val Parsed.Failure(End, 4, _) = withEnd.parse(hexBytes("01 01 01 02 01"))
+        val Parsed.Success(_, 4) = noEnd.parse(hex"01 01 01 02 01")
+        val Parsed.Failure(End, 4, _) = withEnd.parse(hex"01 01 01 02 01")
 
       }
       'start {
         import fastparse.byte._
         val ab = P(((BS(1) | Start) ~ BS(2)).rep ~ End).!
 
-        val Parsed.Success(res1, 4) = ab.parse(hexBytes("01 02 01 02"))
-        assert(res1 == ByteVector(1, 2, 1, 2))
+        val Parsed.Success(res1, 4) = ab.parse(hex"01 02 01 02")
+        assert(res1 == Bytes(1, 2, 1, 2))
 
-        val Parsed.Success(res2, 5) = ab.parse(hexBytes("02 01 02 01 02"))
-        assert(res2 == ByteVector(2, 1, 2, 1, 2))
+        val Parsed.Success(res2, 5) = ab.parse(hex"02 01 02 01 02")
+        assert(res2 == Bytes(2, 1, 2, 1, 2))
 
-        val Parsed.Failure(parser, 2, _) = ab.parse(hexBytes("01 02 02"))
+        val Parsed.Failure(parser, 2, _) = ab.parse(hex"01 02 02")
 
       }
 
       'passfail {
         import fastparse.byte._
-        val Parsed.Success((), 0) = Pass.parse(hexBytes("04 08 15 16 23 42"))
-        val Parsed.Failure(Fail, 0, _) = Fail.parse(hexBytes("04 08 15 16 23 42"))
+        val Parsed.Success((), 0) = Pass.parse(hex"04 08 15 16 23 42")
+        val Parsed.Failure(Fail, 0, _) = Fail.parse(hex"04 08 15 16 23 42")
       }
 
       'index {
         import fastparse.byte._
         val finder = P(BS(1, 1, 1).rep ~ Index ~ BS(2, 2, 2) ~ BS(3, 3, 3).rep)
 
-        val Parsed.Success(9, _) = finder.parse(hexBytes(" 01 01 01  01 01 01  01 01 01  02 02 02  03 03 03"))
+        val Parsed.Success(9, _) = finder.parse(hex" 01 01 01  01 01 01  01 01 01  02 02 02  03 03 03")
       }
 
       'capturing {
         import fastparse.byte._
         val capture1 = P(BS(1).rep.! ~ BS(2) ~ End)
 
-        val Parsed.Success(res1, 4) = capture1.parse(hexBytes("01 01 01 02"))
-        assert(res1 == ByteVector(1, 1, 1))
+        val Parsed.Success(res1, 4) = capture1.parse(hex"01 01 01 02")
+        assert(res1 == Bytes(1, 1, 1))
 
         val capture2 = P(BS(1).rep.! ~ BS(2).! ~ End)
 
-        val Parsed.Success(res2, 4) = capture2.parse(hexBytes("01 01 01 02"))
-        assert(res2 == (ByteVector(1, 1, 1), ByteVector(2)))
+        val Parsed.Success(res2, 4) = capture2.parse(hex"01 01 01 02")
+        assert(res2 == (Bytes(1, 1, 1), Bytes(2)))
 
         val capture3 = P(BS(1).rep.! ~ BS(2).! ~ BS(3).! ~ End)
 
-        val Parsed.Success(res3, 5) = capture3.parse(hexBytes("01 01 01 02 03"))
-        assert(res3 == (ByteVector(1, 1, 1), ByteVector(2), ByteVector(3)))
+        val Parsed.Success(res3, 5) = capture3.parse(hex"01 01 01 02 03")
+        assert(res3 == (Bytes(1, 1, 1), Bytes(2), Bytes(3)))
 
         val captureRep = P(BS(1).!.rep ~ BS(2) ~ End)
 
-        val Parsed.Success(res4, 4) = captureRep.parse(hexBytes("01 01 01 02"))
-        assert(res4 == Seq(ByteVector(1), ByteVector(1), ByteVector(1)))
+        val Parsed.Success(res4, 4) = captureRep.parse(hex"01 01 01 02")
+        assert(res4 == Seq(Bytes(1), Bytes(1), Bytes(1)))
 
         val captureOpt = P(BS(1).rep ~ BS(2).!.? ~ End)
 
-        val Parsed.Success(res5, 4) = captureOpt.parse(hexBytes("01 01 01 02"))
-        assert(res5 == Some(ByteVector(2)))
+        val Parsed.Success(res5, 4) = captureOpt.parse(hex"01 01 01 02")
+        assert(res5 == Some(Bytes(2)))
       }
       'unapply {
         import fastparse.byte._
         val capture1 = P(BS(1).rep.! ~ BS(2) ~ End)
 
-        val capture1(res1) = hexBytes("01 01 01 02")
-        assert(res1 == ByteVector(1, 1, 1))
+        val capture1(res1) = hex"01 01 01 02"
+        assert(res1 == Bytes(1, 1, 1))
 
         val capture2 = P(BS(1).rep.! ~ BS(2).! ~ End)
 
-        val capture2(res2_1, res2_2) = hexBytes("01 01 01 02")
-        assert(res2_1 == ByteVector(1, 1, 1))
-        assert(res2_2 == ByteVector(2))
+        val capture2(res2_1, res2_2) = hex"01 01 01 02"
+        assert(res2_1 == Bytes(1, 1, 1))
+        assert(res2_2 == Bytes(2))
 
         val capture3 = P(BS(1).rep.! ~ BS(2).! ~ BS(3).! ~ End)
 
-        val capture3(res3_1, res3_2, res3_3) = hexBytes("01 01 01 02 03")
-        assert(res3_1 == ByteVector(1, 1, 1))
-        assert(res3_2 == ByteVector(2))
-        assert(res3_3 == ByteVector(3))
+        val capture3(res3_1, res3_2, res3_3) = hex"01 01 01 02 03"
+        assert(res3_1 == Bytes(1, 1, 1))
+        assert(res3_2 == Bytes(2))
+        assert(res3_3 == Bytes(3))
 
         val captureRep = P(BS(1).!.rep ~ BS(2) ~ End)
 
-        val captureRep(res4) = hexBytes("01 01 01 02")
-        assert(res4 == Seq(ByteVector(1), ByteVector(1), ByteVector(1)))
+        val captureRep(res4) = hex"01 01 01 02"
+        assert(res4 == Seq(Bytes(1), Bytes(1), Bytes(1)))
 
         val captureOpt = P(BS(1).rep ~ BS(2).!.? ~ End)
 
-        val captureOpt(res5) = hexBytes("01 01 01 02")
-        assert(res5 == Some(ByteVector(2)))
+        val captureOpt(res5) = hex"01 01 01 02"
+        assert(res5 == Some(Bytes(2)))
       }
       'anybyte {
         import fastparse.byte._
         val ab = P(BS(1) ~ AnyByte.! ~ BS(1))
 
-        val Parsed.Success(res, 3) = ab.parse(hexBytes("01 42 01"))
-        assert(res == ByteVector(0x42))
+        val Parsed.Success(res, 3) = ab.parse(hex"01 42 01")
+        assert(res == Bytes(0x42))
 
-        val failure @ Parsed.Failure(parser, 2, _) = ab.parse(hexBytes("01 42 43 01"))
+        val failure @ Parsed.Failure(parser, 2, _) = ab.parse(hex"01 42 43 01")
 
         assert(
           parser == (BS(1): P0),
@@ -190,19 +190,19 @@ object ByteTests extends TestSuite {
         import fastparse.byte._
         val keyword = P((BS(1, 2, 3) ~ &(BS(4))).!.rep)
 
-        val Parsed.Success(res, _) = keyword.parse(hexBytes("01 02 03 04"))
-        assert(res == Seq(ByteVector(1, 2, 3))
+        val Parsed.Success(res, _) = keyword.parse(hex"01 02 03 04")
+        assert(res == Seq(Bytes(1, 2, 3))
         )
-        val Parsed.Success(Seq(), __) = keyword.parse(hexBytes("01 02 03 05"))
+        val Parsed.Success(Seq(), __) = keyword.parse(hex"01 02 03 05")
       }
       'neglookahead {
         import fastparse.byte._
         val keyword = P(BS(1, 2, 3) ~ !BS(0) ~ AnyByte ~ BS(5, 6, 7)).!
 
-        val Parsed.Success(res, _) = keyword.parse(hexBytes("01 02 03 42 05 06 07"))
-        assert(res == ByteVector(1, 2, 3, 0x42, 5, 6, 7))
+        val Parsed.Success(res, _) = keyword.parse(hex"01 02 03 42 05 06 07")
+        assert(res == Bytes(1, 2, 3, 0x42, 5, 6, 7))
 
-        val Parsed.Failure(parser, 4, _) = keyword.parse(hexBytes("01 02 03 00 05 06 07"))
+        val Parsed.Failure(parser, 4, _) = keyword.parse(hex"01 02 03 00 05 06 07")
         assert(parser == !BS(0))
       }
       'map {
@@ -210,10 +210,10 @@ object ByteTests extends TestSuite {
         val binary = P((BS(0) | BS(1)).rep.!)
         val binaryNum = P(binary.map(_.toArray.sum))
 
-        val Parsed.Success(res, _) = binary.parse(hexBytes("01 01 00 00"))
-        assert(res == ByteVector(1, 1, 0, 0))
+        val Parsed.Success(res, _) = binary.parse(hex"01 01 00 00")
+        assert(res == Bytes(1, 1, 0, 0))
 
-        val Parsed.Success(2, _) = binaryNum.parse(hexBytes("01 01 00 00"))
+        val Parsed.Success(2, _) = binaryNum.parse(hex"01 01 00 00")
       }
     }
 
@@ -229,7 +229,7 @@ object ByteTests extends TestSuite {
         }
 
         check(
-          Foo.ints.parse(hexBytes("ff 00 00 00 00")),
+          Foo.ints.parse(hex"ff 00 00 00 00"),
           """Failure((int | longInt):0 ..."ff 00 00 00 00")"""
         )
 
@@ -243,7 +243,7 @@ object ByteTests extends TestSuite {
           val ints = P( (int | longInt).rep(1) )
         }
         check(
-          Foo.ints.parse(hexBytes("ff 00 00 00 00")),
+          Foo.ints.parse(hex"ff 00 00 00 00"),
           """Failure(AnyByte:5 ..."")"""
         )
       }
@@ -259,7 +259,7 @@ object ByteTests extends TestSuite {
         }
 
 
-        Foo.ints.parse(hexBytes("ff 00 00 00 00"))
+        Foo.ints.parse(hex"ff 00 00 00 00")
 
         val expected = """
             +ints:0
@@ -282,28 +282,32 @@ object ByteTests extends TestSuite {
           import fastparse.byte._
 
           // Constructing a short ByteVector from bytes
-          val a = ByteVector(0x01, 0xff)
+          val a = Bytes(0x01, 0xff)
           assert(a.toString == "ByteVector(2 bytes, 0x01ff)")
 
           // Constructing a ByteVector from an ASCII string
-          val b  = ByteVector("hello":_*)
+          val b  = Bytes("hello":_*)
           assert(b.toString == "ByteVector(5 bytes, 0x68656c6c6f)")
 
           // Constructing a ByteVector copying from a Array[Byte]
           val byteArray = Array[Byte](1, 2, 3, 4)
-          val c = ByteVector(byteArray)
+          val c = Bytes(byteArray)
           assert(c.toString == "ByteVector(4 bytes, 0x01020304)")
 
           // Unsafe construction from an Array[Byte], without copying; assumes
           // You do not mutate the underlying array, otherwise things break.
-          val d = ByteVector.view(byteArray)
+          val d = Bytes.view(byteArray)
           assert(d.toString == "ByteVector(4 bytes, 0x01020304)")
+
+          // Hex Strings
+          val e = hex"cafebabedeadbeef"
+          assert(e.toString == "ByteVector(8 bytes, 0xcafebabedeadbeef)")
         }
         'operations{
           import fastparse.byte._
 
-          val a = ByteVector(0xff, 0xff)
-          val b  = ByteVector(0x01, 0x01)
+          val a = Bytes(0xff, 0xff)
+          val b  = Bytes(0x01, 0x01)
 
           // Simple operations
           assert(
@@ -331,12 +335,12 @@ object ByteTests extends TestSuite {
           assert(
             c.toHex == "ffff0101",
             c.toBase64 == "//8BAQ==",
-            ByteVector.fromHex("ffff0101").get == c,
-            ByteVector.fromHex("""
+            Bytes.fromHex("ffff0101").get == c,
+            Bytes.fromHex("""
               ff ff
               01 01
             """).get == c,
-            ByteVector.fromBase64("//8BAQ==").get == c
+            Bytes.fromBase64("//8BAQ==").get == c
           )
 
 
@@ -347,21 +351,21 @@ object ByteTests extends TestSuite {
           import fastparse.byte._
 
           // Constructing a short ByteVector from bytes
-          val a = bytes(0x01, 0xff)
+          val a = Bytes(0x01, 0xff)
           assert(a.toString == "ByteVector(2 bytes, 0x01ff)")
 
           // Constructing a ByteVector from an ASCII string
-          val b  = bytes("hello":_*)
+          val b  = Bytes("hello":_*)
           assert(b.toString == "ByteVector(5 bytes, 0x68656c6c6f)")
 
           // Constructing a ByteVector copying from a Array[Byte]
           val byteArray = Array[Byte](1, 2, 3, 4)
-          val c = bytes(byteArray)
+          val c = Bytes(byteArray)
           assert(c.toString == "ByteVector(4 bytes, 0x01020304)")
 
           // Unsafe construction from an Array[Byte], without copying; assumes
           // You do not mutate the underlying array, otherwise things break.
-          val d = bytes.view(byteArray)
+          val d = Bytes.view(byteArray)
           assert(d.toString == "ByteVector(4 bytes, 0x01020304)")
         }
       }
@@ -369,11 +373,11 @@ object ByteTests extends TestSuite {
         import fastparse.byte._
 
         assert(
-          hexBytes("01 ff") == ByteVector.fromHex("01 ff").get,
-          hexBytes("""
+          hex"01 ff" == Bytes.fromHex("01 ff").get,
+          hex"""
             de ad be ef
             ca fe ba be
-          """) == ByteVector.fromHex("""
+          """ == Bytes.fromHex("""
             de ad be ef
             ca fe ba be
           """).get
@@ -381,7 +385,7 @@ object ByteTests extends TestSuite {
       }
       'prettyBytesBare{
         import fastparse.byte._
-        val blob = ByteVector(
+        val blob = Bytes(
           "The quick brown fox jumps over the lazy dog. She sells " +
           "sea shells on the sea shore but the shells she sells she " +
           "sells no more. Peter piper picked a pack of pickled peppers.":_*
@@ -403,7 +407,7 @@ object ByteTests extends TestSuite {
       }
       'prettyBytesMarker{
         import fastparse.byte._
-        val blob = ByteVector(
+        val blob = Bytes(
           "The quick brown fox jumps over the lazy dog. She sells " +
           "sea shells on the sea shore but the shells she sells she " +
           "sells no more. Peter piper picked a pack of pickled peppers.":_*
@@ -430,7 +434,7 @@ object ByteTests extends TestSuite {
       'splash{
         import fastparse.byte._
 
-        case class Struct(f: Float, i: Int, s: String, b: ByteVector)
+        case class Struct(f: Float, i: Int, s: String, b: Bytes)
 
         val header = P( BS(0xDE, 0xAD, 0xBE, 0xEF) ~ BE.Float32 ~ BE.Int32 )
 
@@ -440,7 +444,7 @@ object ByteTests extends TestSuite {
 
         val structThing = P( header ~ cString ~ varLengthBlob ~ End).map(Struct.tupled)
 
-        val bytes = ByteVector(
+        val bytes = Bytes(
           0xDE, 0xAD, 0xBE, 0xEF,
           64, 73, 15, -37,
           0, 0, 122, 105,
@@ -464,15 +468,31 @@ object ByteTests extends TestSuite {
         import fastparse.byte._
         val parser = P( BS(0xDE, 0xAD, 0xBE, 0xEF) )
 
-        val Parsed.Success((), 4) = parser.parse(ByteVector(0xDE, 0xAD, 0xBE, 0xEF))
-        val Parsed.Failure(_, 0, _) = parser.parse(ByteVector(0xCA, 0xFE, 0xBA, 0xBE))
+        val Parsed.Success((), 4) = parser.parse(Bytes(0xDE, 0xAD, 0xBE, 0xEF))
+        val Parsed.Failure(_, 0, _) = parser.parse(Bytes(0xCA, 0xFE, 0xBA, 0xBE))
       }
+
+      'bsBytes{
+        import fastparse.byte._
+
+        val parser1 = P( BS(hex"deadbeef") )
+
+        val Parsed.Success((), 4) = parser1.parse(Bytes(0xDE, 0xAD, 0xBE, 0xEF))
+        val Parsed.Failure(_, 0, _) = parser1.parse(Bytes(0xCA, 0xFE, 0xBA, 0xBE))
+
+        val bytes = Bytes(0xDE, 0xfAD, 0xBE, 0xEF)
+        val parser2 = P( BS(bytes) )
+
+        val Parsed.Success((), 4) = parser1.parse(Bytes(0xDE, 0xAD, 0xBE, 0xEF))
+        val Parsed.Failure(_, 0, _) = parser1.parse(Bytes(0xCA, 0xFE, 0xBA, 0xBE))
+      }
+
       'udp{
         import fastparse.byte._
         case class UdpPacket(sourcePort: Int,
                              destPort: Int,
                              checkSum: Int,
-                             data: ByteVector)
+                             data: Bytes)
 
         // BE.UInt16 stands for big-endian unsigned-16-bit-integer parsers
         val udpHeader = P( BE.UInt16 ~ BE.UInt16 ~ BE.UInt16 ~ BE.UInt16 )
@@ -484,11 +504,11 @@ object ByteTests extends TestSuite {
           } yield UdpPacket(sourcePort, destPort, checkSum, data)
         )
 
-        val bytes = hexBytes("""
+        val bytes = hex"""
           04 89 00 35 00 2C AB B4 00 01 01 00 00 01 00 00
           00 00 00 00 04 70 6F 70 64 02 69 78 06 6E 65 74
           63 6F 6D 03 63 6F 6D 00 00 01 00 01
-        """)
+        """
 
         val Parsed.Success(packet, _) = udpParser.parse(bytes)
         assert(
@@ -496,18 +516,18 @@ object ByteTests extends TestSuite {
           packet.destPort == 53,
           packet.checkSum == 43956,
           packet.data.length == 36,
-          packet.data.toSeq == hexBytes("""
+          packet.data == hex"""
             00 01 01 00 00 01 00 00 00 00 00 00 04 70 6F 70
             64 02 69 78 06 6E 65 74 63 6F 6D 03 63 6F 6D 00
             00 01 00 01
-          """).toSeq
+          """
         )
       }
 
       'words{
         import fastparse.byte._
 
-        def allZeroesByteArray = ByteVector(0, 0, 0, 0, 0, 0, 0, 0)
+        def allZeroesByteArray = Bytes(0, 0, 0, 0, 0, 0, 0, 0)
 
         val p1 = P( AnyByte )
         val Parsed.Success((), index1) = p1.parse(allZeroesByteArray)
@@ -535,15 +555,15 @@ object ByteTests extends TestSuite {
         val p = P( Int8 )
 
 
-        val Parsed.Success(result1, _) = p.parse(ByteVector(123)) // 7b
+        val Parsed.Success(result1, _) = p.parse(Bytes(123)) // 7b
         assert(result1 == 123)
 
 
-        val Parsed.Success(result2, _) = p.parse(ByteVector(-123)) // 85
+        val Parsed.Success(result2, _) = p.parse(Bytes(-123)) // 85
         assert(result2 == -123)
 
 
-        val Parsed.Success(result3, _) = p.parse(ByteVector(-1)) // ff
+        val Parsed.Success(result3, _) = p.parse(Bytes(-1)) // ff
         assert(result3 == -1)
       }
 
@@ -554,15 +574,15 @@ object ByteTests extends TestSuite {
         val p = P( UInt8 )
 
 
-        val Parsed.Success(result1, _) = p.parse(ByteVector(123)) // 7b
+        val Parsed.Success(result1, _) = p.parse(Bytes(123)) // 7b
         assert(result1 == 123)
 
 
-        val Parsed.Success(result2, _) = p.parse(ByteVector(-123)) // 85
+        val Parsed.Success(result2, _) = p.parse(Bytes(-123)) // 85
         assert(result2 == 133)
 
 
-        val Parsed.Success(result3, _) = p.parse(ByteVector(-1)) // ff
+        val Parsed.Success(result3, _) = p.parse(Bytes(-1)) // ff
         assert(result3 == 255)
       }
 
@@ -570,23 +590,23 @@ object ByteTests extends TestSuite {
         import fastparse.byte._
 
         val p1 = P( BE.Int16 )
-        val Parsed.Success(result1, _) = p1.parse(ByteVector(1, 0)) // 01 00
+        val Parsed.Success(result1, _) = p1.parse(Bytes(1, 0)) // 01 00
         assert(result1 == 256)
 
 
         val p2 = P( LE.Int16 )
-        val Parsed.Success(result2, _) = p2.parse(ByteVector(1, 0)) // 01 00
+        val Parsed.Success(result2, _) = p2.parse(Bytes(1, 0)) // 01 00
         assert(result2 == 1)
 
 
         val p3 = P( BE.Int32 )
-        val bytes3 = ByteVector(-128, 0, 0, 0) // ff 00 00 00
+        val bytes3 = Bytes(-128, 0, 0, 0) // ff 00 00 00
         val Parsed.Success(result3, _) = p3.parse(bytes3)
         assert(result3 == -2147483648)
 
 
         val p4 = P( LE.Int32 )
-        val bytes4 = ByteVector(-128, 0, 0, 0) // ff 00 00 00
+        val bytes4 = Bytes(-128, 0, 0, 0) // ff 00 00 00
         val Parsed.Success(result4, _) = p4.parse(bytes4)
         assert(result4 == 128)
       }
@@ -597,19 +617,19 @@ object ByteTests extends TestSuite {
 
 
         val p1 = P( BE.Int64 )
-        val bytes1 = ByteVector(1, 0, 0, 0, 0, 0, 0, 0) // 01 00 00 00 00 00 00 00
+        val bytes1 = Bytes(1, 0, 0, 0, 0, 0, 0, 0) // 01 00 00 00 00 00 00 00
         val Parsed.Success(result2, _) = p1.parse(bytes1)
         assert(result2 == 72057594037927936L)
 
 
         val p2 = P( BE.Int32 )
-        val bytes2 = ByteVector(-128, -128, -128, -128) // 80 80 80 80
+        val bytes2 = Bytes(-128, -128, -128, -128) // 80 80 80 80
         val Parsed.Success(result3, _) = p2.parse(bytes2)
         assert(result3 == -2139062144)
 
 
         val p3 = P( BE.UInt32 )
-        val bytes3 = ByteVector(-128, -128, -128, -128) // 80 80 80 80
+        val bytes3 = Bytes(-128, -128, -128, -128) // 80 80 80 80
         val Parsed.Success(result4, _) = p3.parse(bytes3)
         assert(result4 == 2155905152L)
       }
@@ -620,19 +640,19 @@ object ByteTests extends TestSuite {
 
 
         val p1 = P( BE.Float32 )
-        val bytes1 = ByteVector(64, 73, 15, -37) // 40 49 0f db
+        val bytes1 = Bytes(64, 73, 15, -37) // 40 49 0f db
         val Parsed.Success(result1, _) = p1.parse(bytes1)
         assert(math.abs(result1 - 3.1415927) < 0.00001)
 
 
         val p2 = P( LE.Float32 )
-        val bytes2 = ByteVector(-37, 15, 73, 64) // db 0f 49 40
+        val bytes2 = Bytes(-37, 15, 73, 64) // db 0f 49 40
         val Parsed.Success(result2, _) = p2.parse(bytes2)
         assert(math.abs(result2 - 3.1415927) < 0.00001)
 
 
         val p3 = P( BE.Float64 )
-        val bytes3 = ByteVector(64, 9, 33, -5, 84, 68, 45, 24) // 40 09 21 fb 54 44 2d 18
+        val bytes3 = Bytes(64, 9, 33, -5, 84, 68, 45, 24) // 40 09 21 fb 54 44 2d 18
         val Parsed.Success(result3, _) = p3.parse(bytes3)
         assert(math.abs(result3 - 3.1415927) < 0.00001)
       }
@@ -645,7 +665,7 @@ object ByteTests extends TestSuite {
                 markers: Seq[Int] = Seq(-1),
                 contextRows: Int = 8) = {
         val pretty = fastparse.byte.prettyBytes(
-          fastparse.byte.hexBytes(inputHex), markers, contextRows
+          fastparse.byte.Bytes.fromHex(inputHex).get, markers, contextRows
         )
         assert(pretty == expected)
       }
@@ -895,7 +915,7 @@ object ByteTests extends TestSuite {
             ByteOrder.LITTLE_ENDIAN -> leParser
           )
           for((enum, parser) <- cases){
-            val arr = ByteVector.view(put(ByteBuffer.allocate(size).order(enum), i).array())
+            val arr = Bytes.view(put(ByteBuffer.allocate(size).order(enum), i).array())
             val fastparse.byte.Parsed.Success(`i`, `size`) = parser.parse(arr)
           }
 

--- a/fastparse/shared/src/test/scala/fastparse/ByteTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ByteTests.scala
@@ -123,22 +123,22 @@ object ByteTests extends TestSuite {
         val capture2 = P(BS(1).rep.! ~ BS(2).! ~ End)
 
         val Parsed.Success(res2, 4) = capture2.parse(hexBytes("01 01 01 02"))
-        assert(res2 == (BS(1, 1, 1), BS(2)))
+        assert(res2 == (ByteVector(1, 1, 1), ByteVector(2)))
 
         val capture3 = P(BS(1).rep.! ~ BS(2).! ~ BS(3).! ~ End)
 
         val Parsed.Success(res3, 5) = capture3.parse(hexBytes("01 01 01 02 03"))
-        assert(res3 == (BS(1, 1, 1), BS(2), BS(3)))
+        assert(res3 == (ByteVector(1, 1, 1), ByteVector(2), ByteVector(3)))
 
         val captureRep = P(BS(1).!.rep ~ BS(2) ~ End)
 
         val Parsed.Success(res4, 4) = captureRep.parse(hexBytes("01 01 01 02"))
-        assert(res4 == Seq(BS(1), BS(1), BS(1)))
+        assert(res4 == Seq(ByteVector(1), ByteVector(1), ByteVector(1)))
 
         val captureOpt = P(BS(1).rep ~ BS(2).!.? ~ End)
 
         val Parsed.Success(res5, 4) = captureOpt.parse(hexBytes("01 01 01 02"))
-        assert(res5 == Some(BS(2)))
+        assert(res5 == Some(ByteVector(2)))
       }
       'unapply {
         import fastparse.byte._
@@ -163,12 +163,12 @@ object ByteTests extends TestSuite {
         val captureRep = P(BS(1).!.rep ~ BS(2) ~ End)
 
         val captureRep(res4) = hexBytes("01 01 01 02")
-        assert(res4 == Seq(BS(1), BS(1), BS(1)))
+        assert(res4 == Seq(ByteVector(1), ByteVector(1), ByteVector(1)))
 
         val captureOpt = P(BS(1).rep ~ BS(2).!.? ~ End)
 
         val captureOpt(res5) = hexBytes("01 01 01 02")
-        assert(res5 == Some(BS(2)))
+        assert(res5 == Some(ByteVector(2)))
       }
       'anybyte {
         import fastparse.byte._
@@ -201,7 +201,7 @@ object ByteTests extends TestSuite {
         val keyword = P(BS(1, 2, 3) ~ !BS(0) ~ AnyByte ~ BS(5, 6, 7)).!
 
         val Parsed.Success(res, _) = keyword.parse(hexBytes("01 02 03 42 05 06 07"))
-        assert(res == Array(1, 2, 3, 0x42, 5, 6, 7))
+        assert(res == ByteVector(1, 2, 3, 0x42, 5, 6, 7))
 
         val Parsed.Failure(parser, 4, _) = keyword.parse(hexBytes("01 02 03 00 05 06 07"))
         assert(parser == !BS(0))

--- a/fastparse/shared/src/test/scala/fastparse/ByteTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ByteTests.scala
@@ -307,7 +307,7 @@ object ByteTests extends TestSuite {
           import fastparse.byte._
 
           val a = Bytes(0xff, 0xff)
-          val b  = Bytes(0x01, 0x01)
+          val b = Bytes(0x01, 0x01)
 
           // Simple operations
           assert(

--- a/fastparse/shared/src/test/scala/fastparse/MidiParse.scala
+++ b/fastparse/shared/src/test/scala/fastparse/MidiParse.scala
@@ -1,6 +1,6 @@
 package fastparse
-
-import scodec.bits.ByteVector
+import fastparse.byte._
+import BE._
 
 
 case class Midi(format: Int, tickDiv: Midi.TickDiv, tracks: Seq[Seq[(Int, Midi.TrackEvent)]])
@@ -42,12 +42,12 @@ object Midi{
     case class SmpteOffset(hour: Byte, minute: Byte, seconds: Byte, frames: Byte, fractional: Byte) extends MetaEvent
     case class TimeSignature(numerator: Byte, denominator: Byte, clocks: Byte, notatedNotes: Byte) extends MetaEvent
     case class KeySignature(sf: Byte, majorKey: Boolean) extends MetaEvent
-    case class SequencerSpecificEvent(data: ByteVector) extends MetaEvent
-    case class Unknown(data: ByteVector) extends MetaEvent
+    case class SequencerSpecificEvent(data: Bytes) extends MetaEvent
+    case class Unknown(data: Bytes) extends MetaEvent
   }
   sealed trait SysExEvent extends TrackEvent
   object SysExEvent{
-    case class Message(data: ByteVector) extends SysExEvent
+    case class Message(data: Bytes) extends SysExEvent
   }
 }
 
@@ -59,8 +59,7 @@ object Midi{
   * http://www.somascape.org/midi/tech/mfile.html#midi
   */
 object MidiParse{
-  import fastparse.byte._
-  import BE._
+
   import Midi._
   val midiHeader = P( BS(hex"4d 54 68 64 00 00 00 06") ~ Int16 ~ Int16 ~ Int16 )
   val deltaTime = P( BytesWhile(_ < 0, min = 0) ~ AnyByte )

--- a/fastparse/shared/src/test/scala/fastparse/MidiParse.scala
+++ b/fastparse/shared/src/test/scala/fastparse/MidiParse.scala
@@ -62,7 +62,7 @@ object MidiParse{
   import fastparse.byte._
   import BE._
   import Midi._
-  val midiHeader = P( hexBytes("4d 54 68 64 00 00 00 06") ~ Int16 ~ Int16 ~ Int16 )
+  val midiHeader = P( BS(hex"4d 54 68 64 00 00 00 06") ~ Int16 ~ Int16 ~ Int16 )
   val deltaTime = P( BytesWhile(_ < 0, min = 0) ~ AnyByte )
 
   /**
@@ -180,7 +180,7 @@ object MidiParse{
   val trackItem = P( negTrackItemEnd ~ varInt ~ trackEvent ).map{
     case (time, (event, rest)) => (time, event) +: rest
   }
-  val trackHeader = P( hexBytes("4d 54 72 6b") ~/ Int32 )
+  val trackHeader = P( BS(hex"4d 54 72 6b") ~/ Int32 )
   val trackChunk: P[Seq[(Int, TrackEvent)]] = {
     P( trackHeader ~ trackItem.rep() ~ trackItemEnd ).map{
       case (length, events, last) => events.flatten :+ last

--- a/perftests/jvm/src/test/scala/perftests/binary/BmpParse.scala
+++ b/perftests/jvm/src/test/scala/perftests/binary/BmpParse.scala
@@ -9,7 +9,7 @@ import utest._
 object BmpParse extends TestSuite {
   val lenaRecource = getClass.getResource("/lena.bmp")
   val lenaSource = Files.readAllBytes(Paths.get(lenaRecource.toURI.getPath))
-  def lenaIterator(size: Int) = lenaSource.grouped(size)
+  def lenaIterator(size: Int) = lenaSource.grouped(size).map(fastparse.byte.Bytes.view)
   val parser = fastparse.BmpTests.BmpParse.bmp
 
   val tests = TestSuite {
@@ -17,7 +17,7 @@ object BmpParse extends TestSuite {
       Utils.benchmarkAll(
         "ByteParse",
         parser,
-        lenaSource, None,
+        fastparse.byte.Bytes(lenaSource), None,
         lenaIterator
       )
     }

--- a/perftests/jvm/src/test/scala/perftests/binary/ClassParse.scala
+++ b/perftests/jvm/src/test/scala/perftests/binary/ClassParse.scala
@@ -9,14 +9,14 @@ import utest._
 object ClassParse extends TestSuite {
   val collisionResource = getClass.getResource("/CollisionJNI.class")
   val collisionSource = Files.readAllBytes(Paths.get(collisionResource.toURI.getPath))
-  def collisionIterator(size: Int) = collisionSource.grouped(size)
+  def collisionIterator(size: Int) = collisionSource.grouped(size).map(fastparse.byte.Bytes.view)
   val parser = classparse.ClassParse.classFile
 
   val tests = TestSuite {
     Utils.benchmarkAll(
       "ClassParse",
       parser,
-      collisionSource, None,
+      fastparse.byte.Bytes(collisionSource), None,
       collisionIterator
     )
   }

--- a/perftests/jvm/src/test/scala/perftests/binary/MidiParse.scala
+++ b/perftests/jvm/src/test/scala/perftests/binary/MidiParse.scala
@@ -9,14 +9,14 @@ import utest._
 object MidiParse extends TestSuite {
   val goResource = getClass.getResource("/go.mid")
   val goSource = Files.readAllBytes(Paths.get(goResource.toURI.getPath))
-  def goIterator(size: Int) = goSource.grouped(size)
+  def goIterator(size: Int) = goSource.grouped(size).map(fastparse.byte.Bytes.view)
   val parser = fastparse.MidiParse.midiParser
 
   val tests = TestSuite {
     Utils.benchmarkAll(
       "MidiParse",
       parser,
-      goSource, None,
+      fastparse.byte.Bytes(goSource), None,
       goIterator
     )
   }

--- a/readme/ByteParsers.scalatex
+++ b/readme/ByteParsers.scalatex
@@ -52,8 +52,8 @@
             @code{Array[Byte]}, with structural equality, a useful
             @code{toString}, and convenient operations for all the things you
             typically want to do with blobs of bytes. @code{fastparse.byte}'s
-            @code{.parse} method takes @code{Bytes}s as input, and its
-            @sect.ref{Capture} operator captures @code{Bytes}s as output.
+            @code{.parse} method takes @code{Bytes} as input, and its
+            @sect.ref{Capture} operator captures @code{Bytes} as output.
 
         @p
             @code{Bytes} provides convenient methods for construction:

--- a/readme/ByteParsers.scalatex
+++ b/readme/ByteParsers.scalatex
@@ -61,7 +61,9 @@
         @hl.ref(tests/"ByteTests.scala", Seq("'bytevector", "'construction", ""))
 
         @p
-            As well as many useful operations:
+            @code{Bytes} provides many of the common operations that you would
+            want to perform on binary-blobs build in. These more or less match
+            what you would expect from the standard Scala collections:
 
         @hl.ref(tests/"ByteTests.scala", Seq("'bytevector", "'operations", ""))
 
@@ -86,6 +88,16 @@
             Apart from providing an equivalent API for byte parsing,
             FastParse's byte-parsers also provide some helper functions for
             conveniently dealing with binary blobs.
+
+        @sect{Hex Bytes}
+            @hl.ref(tests/"ByteTests.scala", Seq("'hexBytes", ""))
+
+            @p
+                FastParse includes Scodec's hex-interpolator; this is a macro
+                that converts the hex literal in a @code{Bytes} value at
+                compile time. This should be both fast and safe: if you have
+                a type in your hex literal it generates and error at compile
+                time.
 
         @sect{prettyBytes}
             @hl.ref(tests/"ByteTests.scala", Seq("'prettyBytesBare", ""))

--- a/readme/ByteParsers.scalatex
+++ b/readme/ByteParsers.scalatex
@@ -82,21 +82,21 @@
 
     @sect{Byte Helpers}
         @p
-            Apart from providing an equivalent API for byte parsing, FastParse's
-            byte-parsers also provide some helper functions for conveniently dealing
-            with binary blobs.
+            Apart from providing an equivalent API for byte parsing,
+            FastParse's byte-parsers also provide some helper functions for
+            conveniently dealing with binary blobs.
 
-        @sect{BS}
-            @hl.ref(tests/"ByteTests.scala", Seq("'bs", ""))
+        @sect{bytes}
+            @hl.ref(tests/"ByteTests.scala", Seq("'bytes", ""))
             @p
-                This is a shorthand for @code{Array[Byte](...)} that is shorter
-                and saves you a bunch of annoying @code{.toByte} calls.
+                A shorthand for the various @code{ByteVector.apply}
+                constructors; purely for convenience/conciseness
 
         @sect{hexBytes}
             @hl.ref(tests/"ByteTests.scala", Seq("'hexBytes", ""))
             @p
-                Another shorthand for @code{Array[Byte](...)}, that lets you
-                pass in lower-case hexadecimal bytes.
+                A shorthand for the various @code{ByteVector.fromHex}
+                constructor; purely for convenience/conciseness
 
         @sect{prettyBytes}
             @hl.ref(tests/"ByteTests.scala", Seq("'prettyBytesBare", ""))
@@ -119,6 +119,14 @@
             "https://en.wikipedia.org/wiki/Two%27s_complement") integer or
             @lnk("floating point", "https://en.wikipedia.org/wiki/Floating_point")
             number. @code{fastparse.byte} provides built in support for these.
+
+        @sect{BS}
+            @hl.ref(tests/"ByteTests.scala", Seq("'bs", ""))
+            @p
+                This is the equivalent to the @sect.ref{Basic} literal string
+                parser in when parsing strings. If the input matches the given
+                sequence of bytes exactly, it the parse succeeds; if the input
+                does not match or there's not enough input, the parse fails.
 
         @sect{WordN}
             @hl.ref(tests/"ByteTests.scala", Seq("'words", ""))

--- a/readme/ByteParsers.scalatex
+++ b/readme/ByteParsers.scalatex
@@ -40,23 +40,23 @@
         API, there are some new primitives that are specific to byte parsers,
         and some existing primitives that are named slightly differently.
 
-    @sect{ByteVector}
+    @sect{Bytes}
         @p
             The primary data-structure @code{fastparse.byte} works with is
-            @code{ByteVector}. This gets imported when you
+            @code{Bytes}. This gets imported when you
             @hl.scala{import fastparse.byte._}, and is an alias for the
-            excellent @code{ByteVector} class from @lnk("scodec-bits",
-            "https://github.com/scodec/scodec-bits") by
+            excellent @code{scodec.bits.ByteVector} class from
+            @lnk("scodec-bits", "https://github.com/scodec/scodec-bits") by
             @lnk("Michael Pilquist", "https://www.github.com/mpilquist").
-            A @code{ByteVector} is basically an immutable version of
+            @code{Bytes} is basically an immutable version of
             @code{Array[Byte]}, with structural equality, a useful
             @code{toString}, and convenient operations for all the things you
             typically want to do with blobs of bytes. @code{fastparse.byte}'s
-            @code{.parse} method takes @code{ByteVector}s as input, and its
-            @sect.ref{Capture} operator captures @code{ByteVector}s as output.
+            @code{.parse} method takes @code{Bytes}s as input, and its
+            @sect.ref{Capture} operator captures @code{Bytes}s as output.
 
         @p
-            @code{ByteVector} provides convenient methods for construction:
+            @code{Bytes} provides convenient methods for construction:
 
         @hl.ref(tests/"ByteTests.scala", Seq("'bytevector", "'construction", ""))
 
@@ -67,36 +67,25 @@
 
         @p
             These are just the highlights of the most common operations on a
-            @code{ByteVector}. There are many more methods on @code{ByteVector}
-            instances as well as on the @code{ByteVector} companion object, but
+            @code{Bytes}. There are many more methods on @code{Bytes}
+            instances as well as on the @code{Bytes} companion object, but
             you can explore those yourselves in your editor's autocomplete
             menu.
 
         @p
-            In general, it is reasonable to use @code{ByteVector} throughout
+            In general, it is reasonable to use @code{Bytes} throughout
             your codebase where-ever you need to represent binary data. In the
             few cases where performance is of utmost importance, or you really
             need read-write mutability, an @code{Array[Byte]} will be
             necessary, but for the majority of un-changing blobs-of-bytes a
-            @code{ByteVector} will do just fine.
+            @code{Bytes} will do just fine.
+
 
     @sect{Byte Helpers}
         @p
             Apart from providing an equivalent API for byte parsing,
             FastParse's byte-parsers also provide some helper functions for
             conveniently dealing with binary blobs.
-
-        @sect{bytes}
-            @hl.ref(tests/"ByteTests.scala", Seq("'bytes", ""))
-            @p
-                A shorthand for the various @code{ByteVector.apply}
-                constructors; purely for convenience/conciseness
-
-        @sect{hexBytes}
-            @hl.ref(tests/"ByteTests.scala", Seq("'hexBytes", ""))
-            @p
-                A shorthand for the various @code{ByteVector.fromHex}
-                constructor; purely for convenience/conciseness
 
         @sect{prettyBytes}
             @hl.ref(tests/"ByteTests.scala", Seq("'prettyBytesBare", ""))
@@ -122,11 +111,18 @@
 
         @sect{BS}
             @hl.ref(tests/"ByteTests.scala", Seq("'bs", ""))
+
             @p
                 This is the equivalent to the @sect.ref{Basic} literal string
                 parser in when parsing strings. If the input matches the given
                 sequence of bytes exactly, it the parse succeeds; if the input
                 does not match or there's not enough input, the parse fails.
+
+            @p
+                You can also pass in a ByteString to @code{BS} instead of
+                individual byte values:
+
+            @hl.ref(tests/"ByteTests.scala", Seq("'bsBytes", ""))
 
         @sect{WordN}
             @hl.ref(tests/"ByteTests.scala", Seq("'words", ""))

--- a/readme/ByteParsers.scalatex
+++ b/readme/ByteParsers.scalatex
@@ -63,7 +63,7 @@
         @p
             As well as many useful operations:
 
-        @hl.ref(tests/"ByteTests.scala", Seq("'bytevector", "'construction", ""))
+        @hl.ref(tests/"ByteTests.scala", Seq("'bytevector", "'operations", ""))
 
         @p
             These are just the highlights of the most common operations on a

--- a/readme/ByteParsers.scalatex
+++ b/readme/ByteParsers.scalatex
@@ -40,6 +40,46 @@
         API, there are some new primitives that are specific to byte parsers,
         and some existing primitives that are named slightly differently.
 
+    @sect{ByteVector}
+        @p
+            The primary data-structure @code{fastparse.byte} works with is
+            @code{ByteVector}. This gets imported when you
+            @hl.scala{import fastparse.byte._}, and is an alias for the
+            excellent @code{ByteVector} class from @lnk("scodec-bits",
+            "https://github.com/scodec/scodec-bits") by
+            @lnk("Michael Pilquist", "https://www.github.com/mpilquist").
+            A @code{ByteVector} is basically an immutable version of
+            @code{Array[Byte]}, with structural equality, a useful
+            @code{toString}, and convenient operations for all the things you
+            typically want to do with blobs of bytes. @code{fastparse.byte}'s
+            @code{.parse} method takes @code{ByteVector}s as input, and its
+            @sect.ref{Capture} operator captures @code{ByteVector}s as output.
+
+        @p
+            @code{ByteVector} provides convenient methods for construction:
+
+        @hl.ref(tests/"ByteTests.scala", Seq("'bytevector", "'construction", ""))
+
+        @p
+            As well as many useful operations:
+
+        @hl.ref(tests/"ByteTests.scala", Seq("'bytevector", "'construction", ""))
+
+        @p
+            These are just the highlights of the most common operations on a
+            @code{ByteVector}. There are many more methods on @code{ByteVector}
+            instances as well as on the @code{ByteVector} companion object, but
+            you can explore those yourselves in your editor's autocomplete
+            menu.
+
+        @p
+            In general, it is reasonable to use @code{ByteVector} throughout
+            your codebase where-ever you need to represent binary data. In the
+            few cases where performance is of utmost importance, or you really
+            need read-write mutability, an @code{Array[Byte]} will be
+            necessary, but for the majority of un-changing blobs-of-bytes a
+            @code{ByteVector} will do just fine.
+
     @sect{Byte Helpers}
         @p
             Apart from providing an equivalent API for byte parsing, FastParse's

--- a/utils/shared/src/main/scala/fastparse/ElemTypeFormatter.scala
+++ b/utils/shared/src/main/scala/fastparse/ElemTypeFormatter.scala
@@ -1,6 +1,7 @@
 package fastparse
 
 import fastparse.Utils.HexUtils
+import scodec.bits.ByteVector
 
 abstract class ElemTypeFormatter[ElemType] {
   def prettyPrint(input: IndexedSeq[ElemType]): String
@@ -75,8 +76,8 @@ object ResultConverter {
     override def convertFromRepr(input: String): IndexedSeq[Char] = wrapString(input)
   }
 
-  implicit val ByteBuilder = new ResultConverter[Byte, Array[Byte]] {
-    override def convertToRepr(input: IndexedSeq[Byte]): Array[Byte] = input.toArray
-    override def convertFromRepr(input: Array[Byte]): IndexedSeq[Byte] = wrapByteArray(input)
+  implicit val ByteBuilder = new ResultConverter[Byte, ByteVector] {
+    override def convertToRepr(input: IndexedSeq[Byte]): ByteVector = ByteVector(input:_*)
+    override def convertFromRepr(input: ByteVector): IndexedSeq[Byte] = input.toArray
   }
 }


### PR DESCRIPTION
This is an experiment to see what it will look like if we use `ByteVector` instead of `Array[Byte]`. Major changes:

- `hexBytes` is gone, replaced by Scodec's `hex""` interpolator

- FastParse now depends on `scodec-bits`.

- `scodec.bits.ByteVector` is now aliased to `fastparse.byte.Bytes`, usually used as just `Bytes`, for conciseness

- Implicit conversion between `Array[Byte] => Parser[Unit, Byte, Array[Byte]]` is now gone, as if we make it `Bytes => Parser[Unit, Byte, Bytes]`, then using the `|` operator on two `Bytes` values within a parser behaves surprisingly: it bit-wise `|`s the two `Bytes` values together rather than constructing a parser that can parse either.

- `BS` now constructs `Parser[Unit]` instead of constructing `Array[Byte]` and relying on the implicit to convert it to a parser, since the implicit is gone. It is also overloaded to take `Bytes` instead of the literal byte-values, so if you want to convert `Bytes` to a `Parser[Unit]` you just wrap it in `BS`

- Add example unit-tests for `Bytes`/`ByteVector`, and use as documentation on how to use it

- Update all existing parsers in the repo to make use of `Bytes`, `hex""` and the rest of the new API. All the old `.toSeq` calls before comparing arrays are now gone, since `==` works.