### PR TITLE
Add ElemsIn intrinsic

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/Api.scala
+++ b/fastparse/shared/src/main/scala/fastparse/Api.scala
@@ -63,6 +63,7 @@ abstract class Api[Elem, Repr](ct: ClassTag[Elem],
   val AnyElem: P0
   def ElemPred(pred: Elem => Boolean): P0
   def ElemIn(seqs: Seq[Elem]*): P0
+  def ElemsIn(min: Int = 1)(seqs: Seq[Elem]*): P0
   def ElemsWhile(pred: Elem => Boolean, min: Int = 1): P0
 
   def SeqIn(seqs: Repr*) = Intrinsics.StringIn[Elem, Repr](seqs: _*)

--- a/fastparse/shared/src/main/scala/fastparse/StringApi.scala
+++ b/fastparse/shared/src/main/scala/fastparse/StringApi.scala
@@ -19,11 +19,13 @@ class StringApi() extends Api[Char, String](
   def AnyElem(count: Int) = AnyChars(count)
   def CharPred(pred: Char => Boolean): P0 = Intrinsics.ElemPred("CharPred", pred)
   def CharIn(strings: Seq[Char]*) = Intrinsics.ElemIn[Char, String]("CharIn", strings.map(_.toIndexedSeq): _*)
+  def CharsIn(min: Int = 1)(strings: Seq[Char]*) = Intrinsics.ElemsIn[Char, String]("CharsIn", min)(strings.map(_.toIndexedSeq): _*)
   def CharsWhile(pred: Char => Boolean, min: Int = 1) = Intrinsics.ElemsWhile[Char, String]("CharsWhile", pred, min)
 
 
   def ElemPred(pred: Char => Boolean) = CharPred(pred)
   def ElemIn(strings: Seq[Char]*) = CharIn(strings:_*)
+  def ElemsIn(min: Int = 1)(strings: Seq[Char]*) = CharsIn(min)(strings:_*)
   def ElemsWhile(pred: Char => Boolean, min: Int = 1) = CharsWhile(pred, min)
 
 

--- a/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
@@ -257,11 +257,23 @@ object ExampleTests extends TestSuite{
         val Parsed.Success("12345", _) = digits.parse("12345abcde")
         val Parsed.Success("123", _) = digits.parse("123abcde45")
       }
+      'charsIn{
+        val ci = P( CharsIn()("abc", "xyz").! ~ End )
+        val ciMin = P( CharsIn(min = 2)("abc", "xyz").! ~ End )
+
+        val Parsed.Success("aaabbccxyz", _) = ci.parse("aaabbccxyz")
+        val Parsed.Failure(_, 7, _) = ci.parse("aaabbccdxyz.")
+        val Parsed.Failure(_, 1, _) = ciMin.parse("a")
+        val Parsed.Success("aa", _) = ciMin.parse("aa")
+      }
       'charsWhile{
         val cw = P( CharsWhile(_ != ' ').! )
+        val cwMin = P( CharsWhile(_ != ' ', min = 6).! )
 
         val Parsed.Success("12345", _) = cw.parse("12345")
         val Parsed.Success("123", _) = cw.parse("123 45")
+        val Parsed.Failure(_, 5, _) = cwMin.parse("12345")
+        val Parsed.Success("123456", _) = cwMin.parse("123456")
       }
       'stringIn{
         val si = P( StringIn("cow", "cattle").!.rep )

--- a/fastparseByte/shared/src/main/scala/fastparse/byte/ByteApi.scala
+++ b/fastparseByte/shared/src/main/scala/fastparse/byte/ByteApi.scala
@@ -14,6 +14,7 @@ class ByteApi() extends Api[Byte, ByteVector](
   def AnyBytes(count: Int) = Terminals.AnyElems[Byte, Bytes]("AnyBytes", count)
   def BytePred(pred: Byte => Boolean): P0 = Intrinsics.ElemPred("BytePred", pred)
   def ByteIn(seqs: Seq[Byte]*) = Intrinsics.ElemIn[Byte, Bytes]("ByteIn", seqs.map(_.toIndexedSeq): _*)
+  def BytesIn(min: Int = 1)(seqs: Seq[Byte]*) = Intrinsics.ElemsIn[Byte, Bytes]("ByteIn", min)(seqs.map(_.toIndexedSeq): _*)
   def BytesWhile(pred: Byte => Boolean, min: Int = 1) = Intrinsics.ElemsWhile[Byte, Bytes]("BytesWhile", pred, min)
 
 
@@ -21,6 +22,7 @@ class ByteApi() extends Api[Byte, ByteVector](
   def AnyElems(count: Int) = AnyBytes(count)
   def ElemPred(pred: Byte => Boolean) = BytePred(pred)
   def ElemIn(strings: Seq[Byte]*) = ByteIn(strings:_*)
+  def ElemsIn (min: Int = 1)(strings: Seq[Byte]*) = BytesIn(min)(strings:_*)
   def ElemsWhile(pred: Byte => Boolean, min: Int = 1) = BytesWhile(pred, min)
 
   /**


### PR DESCRIPTION
`ElemWhile` requires enumerating every character there is on initialization, which is slow (at least in JS) but `ElemIn` and `.rep` are too slow at parse-time for some applications, for the same reason there's an `ElemWhile` in the first place. Thus, there is a need for a primitive combinator combining `ElemWhile` and `ElemIn`.