### PR TITLE
pythonparse: Parse unary operations and negative numbers

### DIFF
--- a/pythonparse/shared/src/main/scala/pythonparse/Ast.scala
+++ b/pythonparse/shared/src/main/scala/pythonparse/Ast.scala
@@ -146,7 +146,7 @@ object Ast{
     case object Invert extends unaryop
     case object Not extends unaryop
     case object UAdd extends unaryop
-    case object USubextends extends unaryop
+    case object USub extends unaryop
   }
   sealed trait cmpop
   object cmpop{

--- a/pythonparse/shared/src/main/scala/pythonparse/Expressions.scala
+++ b/pythonparse/shared/src/main/scala/pythonparse/Expressions.scala
@@ -73,9 +73,9 @@ object Expressions {
   val BitAnd = op("&", Ast.operator.BitAnd)
   val BitXor = op("^", Ast.operator.BitXor)
   val UAdd = op("+", Ast.unaryop.UAdd)
-  val USubextends = op("-", Ast.unaryop.USubextends)
+  val USub = op("-", Ast.unaryop.USub)
   val Invert = op("~", Ast.unaryop.Invert)
-  val unary_op = P ( UAdd | USubextends | Invert )
+  val unary_op = P ( UAdd | USub | Invert )
 
 
   def Unary(p: P[Ast.expr]) =
@@ -96,7 +96,7 @@ object Expressions {
   val term: P[Ast.expr] = P( Chain(factor, Mult | Div | Mod | FloorDiv) )
   // NUMBER appears here and below in `atom` to give it precedence.
   // This ensures that "-2" will parse as `Num(-2)` rather than
-  // as `UnaryOp(USubextends, Num(2))`.
+  // as `UnaryOp(USub, Num(2))`.
   val factor: P[Ast.expr] = P( NUMBER | Unary(factor) | power )
   val power: P[Ast.expr] = P( atom ~ trailer.rep ~ (Pow ~ factor).? ).map{
     case (lhs, trailers, rhs) =>

--- a/pythonparse/shared/src/main/scala/pythonparse/Lexical.scala
+++ b/pythonparse/shared/src/main/scala/pythonparse/Lexical.scala
@@ -48,9 +48,13 @@ object Lexical {
 
   val escapeseq: P0 = P( "\\" ~ AnyChar )
 
+  def negatable[T](p: P[T])(implicit ev: Numeric[T]) = (("+" | "-").?.! ~ p).map {
+    case ("-", i) => ev.negate(i)
+    case (_, i) => i
+  }
 
   val longinteger: P[BigInt] = P( integer ~ ("l" | "L") )
-  val integer: P[BigInt] = P( octinteger | hexinteger | bininteger | decimalinteger)
+  val integer: P[BigInt] = negatable[BigInt](P( octinteger | hexinteger | bininteger | decimalinteger))
   val decimalinteger: P[BigInt] = P( nonzerodigit ~ digit.rep | "0" ).!.map(scala.BigInt(_))
   val octinteger: P[BigInt] = P( "0" ~ ("o" | "O") ~ octdigit.rep(1).! | "0" ~ octdigit.rep(1).! ).map(scala.BigInt(_, 8))
   val hexinteger: P[BigInt] = P( "0" ~ ("x" | "X") ~ hexdigit.rep(1).! ).map(scala.BigInt(_, 16))
@@ -61,7 +65,7 @@ object Lexical {
   val hexdigit: P0 = P( digit | CharIn('a' to 'f', 'A' to 'F') )
 
 
-  val floatnumber: P[BigDecimal] = P( pointfloat | exponentfloat )
+  val floatnumber: P[BigDecimal] = negatable[BigDecimal](P( pointfloat | exponentfloat ))
   val pointfloat: P[BigDecimal] = P( intpart.? ~ fraction | intpart ~ "." ).!.map(BigDecimal(_))
   val exponentfloat: P[BigDecimal] = P( (intpart | pointfloat) ~ exponent ).!.map(BigDecimal(_))
   val intpart: P[BigDecimal] = P( digit.rep(1) ).!.map(BigDecimal(_))

--- a/pythonparse/shared/src/test/scala/pythonparse/RegressionTests.scala
+++ b/pythonparse/shared/src/test/scala/pythonparse/RegressionTests.scala
@@ -239,7 +239,7 @@ object RegressionTests extends TestSuite{
     )
     'unary_subtraction - TestUtils.check(
       Statements.file_input,
-      Seq(Expr(UnaryOp(USubextends, Name(identifier("foo"), Load)))),
+      Seq(Expr(UnaryOp(USub, Name(identifier("foo"), Load)))),
       "-foo"
     )
   }

--- a/pythonparse/shared/src/test/scala/pythonparse/RegressionTests.scala
+++ b/pythonparse/shared/src/test/scala/pythonparse/RegressionTests.scala
@@ -232,6 +232,16 @@ object RegressionTests extends TestSuite{
       "while 1:\n\tpass"
     )
 
+    'negative_integer - TestUtils.check(
+      Statements.file_input,
+      Seq(Expr(Num(-1))),
+      "-1"
+    )
+    'unary_subtraction - TestUtils.check(
+      Statements.file_input,
+      Seq(Expr(UnaryOp(USubextends, Name(identifier("foo"), Load)))),
+      "-foo"
+    )
   }
 }
 

--- a/pythonparse/shared/src/test/scala/pythonparse/UnitTests.scala
+++ b/pythonparse/shared/src/test/scala/pythonparse/UnitTests.scala
@@ -24,7 +24,12 @@ object UnitTests extends TestSuite{
 
       'primitives {
         'int - expr(Num(1.0), "1")
+        'negative_int - expr(Num(-1.0), "-1")
         'float - expr(Num(1.5), "1.5")
+        'negative_float - expr(Num(-0.45), "-0.45")
+        'long - expr(Num(10), "10L")
+        'long_lowercase - expr(Num(25), "25l")
+        'negative_long - expr(Num(-50), "-50L")
         'emptyTuple - expr(Tuple(Nil, Load), "()")
         'name - expr(Name(identifier("None"), Load), "None")
         'yield - expr(Yield(None), "(yield)")
@@ -62,6 +67,42 @@ object UnitTests extends TestSuite{
             )
           ),
           "not not a"
+        )
+        'unary_invert - expr(
+          UnaryOp(
+            Invert,
+            'a
+          ),
+          "~a"
+        )
+        'unary_negation - expr(
+          UnaryOp(
+            USubextends,
+            'b
+          ),
+          "-b"
+        )
+        'unary_negative_number_negation - expr(
+          UnaryOp(
+            USubextends,
+            Num(-1)
+          ),
+          "--1"
+        )
+        'unary_add - expr(
+          UnaryOp(
+            UAdd,
+            'c
+          ),
+          "+c"
+        )
+        'unary_precedence - expr(
+          BinOp(
+            BinOp(UnaryOp(USubextends, 'a), Add, 'b),
+            Sub,
+            'c
+          ),
+          "-a + b - c"
         )
         'comparison - expr(
           Compare(

--- a/pythonparse/shared/src/test/scala/pythonparse/UnitTests.scala
+++ b/pythonparse/shared/src/test/scala/pythonparse/UnitTests.scala
@@ -77,14 +77,14 @@ object UnitTests extends TestSuite{
         )
         'unary_negation - expr(
           UnaryOp(
-            USubextends,
+            USub,
             'b
           ),
           "-b"
         )
         'unary_negative_number_negation - expr(
           UnaryOp(
-            USubextends,
+            USub,
             Num(-1)
           ),
           "--1"
@@ -98,7 +98,7 @@ object UnitTests extends TestSuite{
         )
         'unary_precedence - expr(
           BinOp(
-            BinOp(UnaryOp(USubextends, 'a), Add, 'b),
+            BinOp(UnaryOp(USub, 'a), Add, 'b),
             Sub,
             'c
           ),


### PR DESCRIPTION
### Summary

This PR allows `pythonparse` to recognize two previously-ignored constructs:

- Negative number literals.
- Unary operations `UAdd`, `USub`, and `Invert`.

### Details

Previously, `pythonparse` discarded these operators, rather than surfacing them as part of the constructed `Ast`. The logic linked below was responsible for discarding unary operators:

https://github.com/lihaoyi/fastparse/compare/master...jeremydhoon:jhoon-unaryop-invert?expand=1#diff-7fe7f240cf772c974bc24a8ecc6bd120L91

To capture these operators properly, the PR makes three changes:
- When parsing numbers, we capture a preceding sign operator and use it in computing the number's Scala value.
- When parsing `factor`s, we capture preceding unary operators, wrapping the subsequent expression with a `UnaryOp` if found.
- Before attempting to parse a `factor`, we first attempt to parse a `NUMBER`. This ensures numbers will parse as `Num(-1)` rather than `UnaryOp(USub, Num(1))`.

### Testing

I added a handful of regression tests initially, and then added a number unit tests as well. I'd be more than happy shift tests around to their proper files if this was not the correct arrangement.

When writing tests, I tried to ensure that the expected parse tree matched that returned by Python's `ast` module with `ast.dump(ast.parse("..."))`.