### PR TITLE
pythonparse: Do not parse parenthetical expressions as single-item tuples

### DIFF
--- a/pythonparse/shared/src/main/scala/pythonparse/Expressions.scala
+++ b/pythonparse/shared/src/main/scala/pythonparse/Expressions.scala
@@ -105,7 +105,7 @@ object Expressions {
       empty_tuple  |
       empty_list |
       empty_dict |
-      "(" ~ (yield_expr | generator | tuple) ~ ")" |
+      "(" ~ (yield_expr | generator | tuple | test) ~ ")" |
       "[" ~ (list_comp | list) ~ "]" |
       "{" ~ dictorsetmaker ~ "}" |
       "`" ~ testlist1.map(x => Ast.expr.Repr(Ast.expr.Tuple(x, Ast.expr_context.Load))) ~ "`" |
@@ -116,7 +116,8 @@ object Expressions {
   }
   val list_contents = P( test.rep(1, ",") ~ ",".? )
   val list = P( list_contents ).map(Ast.expr.List(_, Ast.expr_context.Load))
-  val tuple = P( list_contents).map(Ast.expr.Tuple(_, Ast.expr_context.Load))
+  val tuple_contents = P( test ~ "," ~ list_contents.?).map { case (head, rest)  => head +: rest.getOrElse(Seq.empty) }
+  val tuple = P( tuple_contents).map(Ast.expr.Tuple(_, Ast.expr_context.Load))
   val list_comp_contents = P( test ~ comp_for.rep(1) )
   val list_comp = P( list_comp_contents ).map(Ast.expr.ListComp.tupled)
   val generator = P( list_comp_contents ).map(Ast.expr.GeneratorExp.tupled)

--- a/pythonparse/shared/src/test/scala/pythonparse/UnitTests.scala
+++ b/pythonparse/shared/src/test/scala/pythonparse/UnitTests.scala
@@ -71,6 +71,10 @@ object UnitTests extends TestSuite{
           ),
           "a < b <= c > d >= e == f != g in h not in i"
         )
+        'parenthetical_grouping - expr(
+          BinOp(BinOp('a, Add, 'b), Mult, BinOp('c, Sub, 'd)),
+          "(a + b) * (c - d)"
+        )
       }
       'chained{
         'attributes - expr(
@@ -104,6 +108,10 @@ object UnitTests extends TestSuite{
         'tuple - expr(
           Tuple(Seq(Num(1.0), Num(2.0), Str("a")), Load),
           "(1, 2, 'a')"
+        )
+        'single_item_tuple - expr(
+          Tuple(Seq(Num(1.0)), Load),
+          "(1,)"
         )
         'set - expr(
           Set(Seq(Num(1.0), Num(2.0), Str("a"))),


### PR DESCRIPTION
### Summary

When parsing an expression such as `(a + b) * (c - d)`, the parenthesized terms should be treated as scalar expressions. The current behavior in `pythonparse` is to treat these terms as single-item tuples.

### Details

The PR adds a different parser for the contents of tuples, which ensure the presence of at least one `test` followed by a comma in order to consider the expression a tuple. To capture the scalar expression case, the PR adds a case for `test` to the parser for parenthesized terms under `atom`.

### Testing

The PR adds two brief unit test cases. I verified that the expected parses match the results produced by `ast.dump(ast.parse('...'))` in Python.