### PR TITLE
Scalaparse: Add support for <xml:unparsed>

### DIFF
--- a/scalaparse/shared/src/main/scala/scalaparse/Xml.scala
+++ b/scalaparse/shared/src/main/scala/scalaparse/Xml.scala
@@ -75,7 +75,12 @@ trait Xml extends Core {
     val ETag = P( "</" ~ Name ~ WL.? ~ ">" )
     val Content = P( (CharData | Content1).rep )
     val Content1  = P( XmlContent | Reference | ScalaExpr )
-    val XmlContent: P0 = P( Element | CDSect | PI | Comment )
+    val XmlContent: P0 = P( Element | CDSect | PI | Comment | Unparsed )
+
+    val Unparsed = P( UnparsedStart ~ UnparsedData ~ UnparsedEnd )
+    val UnparsedStart = P( "<xml:unparsed" ~ (WL ~ Attribute).rep ~ WL.? ~ ">" )
+    val UnparsedEnd = P ( "</xml:unparsed>" )
+    val UnparsedData = P ( (!UnparsedEnd ~ AnyChar).rep )
 
     val CDSect = P( CDStart ~ CData ~ CDEnd )
     val CDStart = P( "<![CDATA[" )

--- a/scalaparse/shared/src/test/scala/scalaparse/unit/FailureTests.scala
+++ b/scalaparse/shared/src/test/scala/scalaparse/unit/FailureTests.scala
@@ -835,6 +835,16 @@ object FailureTests extends TestSuite{
         expected = """ "\"\"\"" | StringChars | Interp | NonTripleQuoteChar """,
         found = ""
       )
+      * - checkNeg(
+        """
+          |object System {
+          |  e match { case <xml:unparsed><</xml:unparsed> => }
+          |}
+          |
+        """.stripMargin,
+        expected = """CharsWhile(<function1>) | XmlPattern | Thingy | PatLiteral | TupleEx | Extractor | VarId""",
+        found = ":unparsed>"
+      )
 
   }
 }

--- a/scalaparse/shared/src/test/scala/scalaparse/unit/SuccessTests.scala
+++ b/scalaparse/shared/src/test/scala/scalaparse/unit/SuccessTests.scala
@@ -1169,6 +1169,16 @@ object SuccessTests extends TestSuite{
       """.stripMargin
     )
     * - check(
+      """object K{
+        |    <xml:unparsed></xml:unparsed>
+        |    <xml:unparsed foo=""></xml:unparsed>
+        |    <xml:unparsed><</xml:unparsed>
+        |    <xml:unparsed>{foo}</xml:unparsed>
+        |    <xml:unparsed></xml:unparse></xml:unparsed>
+        |}
+      """.stripMargin
+    )
+    * - check(
       """object X{
         |   pomExtra :=
         |      <url>https://github.com/lihaoyi/scalatags</url>


### PR DESCRIPTION
@lihaoyi For some reason this succeed
```scala
scala> scalaparse.Scala.XmlExpr.parse("""<xml:unparsed></xml:unparse></xml:unparsed>""")
res14: fastparse.core.Parsed[Unit,Char,String] = Success((),28)
```
But it fails within an `object`
```scala
scala> scalaparse.Scala.CompilationUnit.parse("""object K { <xml:unparsed></xml:unparse></xml:unparsed> }""")
res16: fastparse.core.Parsed[Unit,Char,String] = Failure("}":1:54 ..."> }")
```