### PR TITLE
Reorganize build for easier cross-publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Common Commands
 - `sbt ~fastparseJVM/test` runs the main testsuite. If you're hacking on FastParse, this is often where you want to go
 - You can run the other suites for `fastparseJS`, `scalaparseJVM`, etc. if you wish, but I typically don't and leave that to CI unless I'm actively working on the sub-project
 - You can use `+` to run it under different Scala versions, but again I usually don't bother
-- `+modules/test` is the aggregate test-all command, and `+modules/publishSigned` is publish-all. Other things (`compile`, etc.) can also be run on `modules`
+- `very test` is the aggregate test-all command, and `very publishSigned` is publish-all. Other things (`compile`, etc.) can also be run prefixed with `very`
 - `readme/run` builds the documentation site, which can then be found at `readme/target/scalatex/index.html`
 
 Contribution Guidelines

--- a/build.sbt
+++ b/build.sbt
@@ -2,16 +2,7 @@ val Constants = _root_.fastparse.Constants
 import sbtcrossproject.{crossProject, CrossType}
 import sbt.Keys._
 
-publishArtifact := false
-
-publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
-
-lazy val nativeSettings = Seq(
-  scalaVersion := Constants.scala211,
-  crossScalaVersions := Seq(Constants.scala211)
-)
-
-scalaJSUseRhino in Global := false
+noPublish
 
 def macroDependencies(version: String) =
   Seq(
@@ -61,6 +52,18 @@ val shared = Seq(
       </developers>
 )
 
+lazy val nativeSettings = Seq(
+  scalaVersion := Constants.scala211,
+  crossScalaVersions := Seq(Constants.scala211)
+)
+
+lazy val noPublish = Seq(
+  publishArtifact := false,
+  publish := {},
+  publishLocal := {}
+)
+
+
 lazy val utils = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(shared:_*)
   .settings(
@@ -85,7 +88,8 @@ lazy val fastparse = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(shared:_*)
   .settings(
     name := "fastparse",
-    sourceGenerators in Compile <+= sourceManaged in Compile map { dir =>
+    sourceGenerators in Compile += Def.task {
+      val dir = (sourceManaged in Compile).value 
       val file = dir/"fastparse"/"core"/"SequencerGen.scala"
       // Only go up to 21, because adding the last element makes it 22
       val tuples = (2 to 21).map{ i =>
@@ -200,6 +204,7 @@ lazy val perftests = crossProject(JSPlatform, JVMPlatform)
   )
   .settings(shared:_*)
   .settings(
+    noPublish,
     name := "perfomance-tests",
     parallelExecution := false
   )
@@ -229,10 +234,7 @@ lazy val modules = project
     utilsJVM,
     utilsNative
   )
-  .settings(
-    publishArtifact := false,
-    publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
-  )
+  .settings(noPublish)
 
 lazy val demo = project.enablePlugins(ScalaJSPlugin)
   .dependsOn(
@@ -247,8 +249,7 @@ lazy val demo = project.enablePlugins(ScalaJSPlugin)
     libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.2",
     libraryDependencies += "com.lihaoyi" %%% "scalatags" % "0.6.5",
     emitSourceMaps := false,
-    publishArtifact := false,
-    publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
+    noPublish
   )
 lazy val readme = scalatex.ScalatexReadme(
   projectId = "readme",
@@ -261,7 +262,7 @@ lazy val readme = scalatex.ScalatexReadme(
     (fullOptJS in (demo, Compile)).value
     (artifactPath in (demo,  Compile, fullOptJS )).value
   },
+  crossScalaVersions := List(Constants.scala212),
   (unmanagedSources in Compile) += baseDirectory.value/".."/"project"/"Constants.scala",
-  publishArtifact := false,
-  publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
+  noPublish
 )

--- a/build.sbt
+++ b/build.sbt
@@ -65,8 +65,8 @@ lazy val noPublish = Seq(
 
 
 lazy val utils = crossProject(JSPlatform, JVMPlatform, NativePlatform)
-  .settings(shared:_*)
   .settings(
+    shared,
     name := "fastparse-utils",
     unmanagedSourceDirectories in Compile ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
@@ -85,8 +85,8 @@ lazy val utilsNative = utils.native
 
 lazy val fastparse = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .dependsOn(utils)
-  .settings(shared:_*)
   .settings(
+    shared,
     name := "fastparse",
     sourceGenerators in Compile += Def.task {
       val dir = (sourceManaged in Compile).value 
@@ -128,8 +128,8 @@ lazy val fastparseNative = fastparse.native
 
 lazy val fastparseByte = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(fastparse)
-  .settings(shared:_*)
   .settings(
+    shared,
     name := "fastparse-byte",
     libraryDependencies += "org.scodec" %%% "scodec-bits" % "1.1.5"
   )
@@ -140,19 +140,17 @@ lazy val fastparseByteJVM = fastparseByte.jvm
 
 lazy val scalaparse = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .dependsOn(fastparse)
-  .settings(shared:_*)
   .settings(
+    shared,
     name := "scalaparse"
-    )
+  )
   .jvmSettings(
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test"
   )
   .nativeSettings(nativeSettings)
 
 lazy val scalaparseJS = scalaparse.js
-
 lazy val scalaparseJVM = scalaparse.jvm
-
 lazy val scalaparseNative = scalaparse.native
 
 
@@ -164,7 +162,6 @@ lazy val pythonparse = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .nativeSettings(nativeSettings)
 
-
 lazy val pythonparseJVM = pythonparse.jvm
 lazy val pythonparseJS = pythonparse.js
 lazy val pythonparseNative = pythonparse.native
@@ -172,8 +169,10 @@ lazy val pythonparseNative = pythonparse.native
 
 lazy val cssparse = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .dependsOn(fastparse)
-  .settings(name := "cssparse")
-  .settings(shared:_*)
+  .settings(
+    shared,
+    name := "cssparse"
+  )
   .jvmSettings(
     libraryDependencies += "net.sourceforge.cssparser" % "cssparser" % "0.9.18" % "test"
   )
@@ -185,8 +184,8 @@ lazy val cssparseNative = cssparse.native
 
 lazy val classparse = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(fastparseByte)
-  .settings(shared:_*)
   .settings(
+    shared,
     name := "classparse"
   )
 
@@ -202,8 +201,8 @@ lazy val perftests = crossProject(JSPlatform, JVMPlatform)
     cssparse,
     classparse
   )
-  .settings(shared:_*)
   .settings(
+    shared,
     noPublish,
     name := "perfomance-tests",
     parallelExecution := false
@@ -234,7 +233,10 @@ lazy val modules = project
     utilsJVM,
     utilsNative
   )
-  .settings(noPublish)
+  .settings(
+    shared,
+    noPublish
+  )
 
 lazy val demo = project.enablePlugins(ScalaJSPlugin)
   .dependsOn(
@@ -244,8 +246,8 @@ lazy val demo = project.enablePlugins(ScalaJSPlugin)
     cssparseJS,
     classparseJS
   )
-  .settings(shared:_*)
   .settings(
+    shared,
     libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.2",
     libraryDependencies += "com.lihaoyi" %%% "scalatags" % "0.6.5",
     emitSourceMaps := false,

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ val Constants = _root_.fastparse.Constants
 import sbtcrossproject.{crossProject, CrossType}
 import sbt.Keys._
 
+shared
 noPublish
 
 def macroDependencies(version: String) =
@@ -60,7 +61,8 @@ lazy val nativeSettings = Seq(
 lazy val noPublish = Seq(
   publishArtifact := false,
   publish := {},
-  publishLocal := {}
+  publishLocal := {},
+  PgpKeys.publishSigned := {}
 )
 
 lazy val utils = crossProject(JSPlatform, JVMPlatform, NativePlatform)
@@ -228,6 +230,7 @@ lazy val readme = scalatex.ScalatexReadme(
   source = "Readme",
   autoResources = List("demo-opt.js")
 ).settings(
+  shared,
   (resources in Compile) += {
     (fullOptJS in (demo, Compile)).value
     (artifactPath in (demo,  Compile, fullOptJS )).value

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+val Constants = _root_.fastparse.Constants
 import sbtcrossproject.{crossProject, CrossType}
 import sbt.Keys._
 
@@ -5,15 +6,9 @@ publishArtifact := false
 
 publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
 
-lazy val scala210 = "2.10.6"
-lazy val scala211 = "2.11.11"
-lazy val scala212 = "2.12.3"
-
-crossScalaVersions := Seq(scala210, scala211, scala212)
-
 lazy val nativeSettings = Seq(
-  scalaVersion := scala211,
-  crossScalaVersions := Seq(scala211)
+  scalaVersion := Constants.scala211,
+  crossScalaVersions := Seq(Constants.scala211)
 )
 
 scalaJSUseRhino in Global := false
@@ -37,8 +32,9 @@ val shared = Seq(
   ),
   scalaJSStage in Global := FullOptStage,
   organization := "com.lihaoyi",
-  version := _root_.fastparse.Constants.version,
-  scalaVersion := scala212,
+  version := Constants.version,
+  scalaVersion := Constants.scala212,
+  crossScalaVersions := Seq(Constants.scala210, Constants.scala211, Constants.scala212),
   libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.1.5" % "provided",
   addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.5"),
   autoCompilerPlugins := true,

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,6 @@ lazy val noPublish = Seq(
   publishLocal := {}
 )
 
-
 lazy val utils = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     shared,
@@ -81,7 +80,6 @@ lazy val utils = crossProject(JSPlatform, JVMPlatform, NativePlatform)
 lazy val utilsJS = utils.js
 lazy val utilsJVM= utils.jvm
 lazy val utilsNative = utils.native
-
 
 lazy val fastparse = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .dependsOn(utils)
@@ -121,7 +119,6 @@ lazy val fastparse = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   // In order to make the midi-parser-test in fastparseJVM/test:run work
   .jvmSettings(fork in (Test, run) := true)
   .nativeSettings(nativeSettings)
-
 lazy val fastparseJS = fastparse.js
 lazy val fastparseJVM = fastparse.jvm
 lazy val fastparseNative = fastparse.native
@@ -133,7 +130,6 @@ lazy val fastparseByte = crossProject(JSPlatform, JVMPlatform)
     name := "fastparse-byte",
     libraryDependencies += "org.scodec" %%% "scodec-bits" % "1.1.5"
   )
-
 lazy val fastparseByteJS = fastparseByte.js
 lazy val fastparseByteJVM = fastparseByte.jvm
 // Native support blocked by https://github.com/scala-native/scala-native/issues/925
@@ -148,7 +144,6 @@ lazy val scalaparse = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test"
   )
   .nativeSettings(nativeSettings)
-
 lazy val scalaparseJS = scalaparse.js
 lazy val scalaparseJVM = scalaparse.jvm
 lazy val scalaparseNative = scalaparse.native
@@ -161,7 +156,6 @@ lazy val pythonparse = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     name := "pythonparse"
   )
   .nativeSettings(nativeSettings)
-
 lazy val pythonparseJVM = pythonparse.jvm
 lazy val pythonparseJS = pythonparse.js
 lazy val pythonparseNative = pythonparse.native
@@ -177,7 +171,6 @@ lazy val cssparse = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     libraryDependencies += "net.sourceforge.cssparser" % "cssparser" % "0.9.18" % "test"
   )
   .nativeSettings(nativeSettings)
-
 lazy val cssparseJVM = cssparse.jvm
 lazy val cssparseJS = cssparse.js
 lazy val cssparseNative = cssparse.native
@@ -188,7 +181,6 @@ lazy val classparse = crossProject(JSPlatform, JVMPlatform)
     shared,
     name := "classparse"
   )
-
 lazy val classparseJVM = classparse.jvm
 lazy val classparseJS = classparse.js
 
@@ -207,36 +199,10 @@ lazy val perftests = crossProject(JSPlatform, JVMPlatform)
     name := "perfomance-tests",
     parallelExecution := false
   )
-
 lazy val perftestsJVM = perftests.jvm
 lazy val perftestsJS = perftests.js
 
-lazy val modules = project
-  .aggregate(
-    fastparseJS,
-    fastparseJVM,
-    fastparseNative,
-    fastparseByteJS,
-    fastparseByteJVM,
-    pythonparseJS,
-    pythonparseJVM,
-    pythonparseNative,
-    cssparseJS,
-    cssparseJVM,
-    cssparseNative,
-    scalaparseJS,
-    scalaparseJVM,
-    scalaparseNative,
-    classparseJVM,
-    classparseJS,
-    utilsJS,
-    utilsJVM,
-    utilsNative
-  )
-  .settings(
-    shared,
-    noPublish
-  )
+lazy val is212Only = List(crossScalaVersions := List(Constants.scala212))
 
 lazy val demo = project.enablePlugins(ScalaJSPlugin)
   .dependsOn(
@@ -248,11 +214,13 @@ lazy val demo = project.enablePlugins(ScalaJSPlugin)
   )
   .settings(
     shared,
+    is212Only,
     libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.2",
     libraryDependencies += "com.lihaoyi" %%% "scalatags" % "0.6.5",
     emitSourceMaps := false,
     noPublish
   )
+
 lazy val readme = scalatex.ScalatexReadme(
   projectId = "readme",
   wd = file(""),
@@ -264,7 +232,7 @@ lazy val readme = scalatex.ScalatexReadme(
     (fullOptJS in (demo, Compile)).value
     (artifactPath in (demo,  Compile, fullOptJS )).value
   },
-  crossScalaVersions := List(Constants.scala212),
+  is212Only,
   (unmanagedSources in Compile) += baseDirectory.value/".."/"project"/"Constants.scala",
   noPublish
 )

--- a/project/Constants.scala
+++ b/project/Constants.scala
@@ -1,4 +1,7 @@
 package fastparse
 object Constants{
   val version = "0.4.3"
+  val scala210 = "2.10.6"
+  val scala211 = "2.11.11"
+  val scala212 = "2.12.3"
 }

--- a/project/Constants.scala
+++ b/project/Constants.scala
@@ -1,6 +1,6 @@
 package fastparse
 object Constants{
-  val version = "0.4.3"
+  val version = "0.4.4"
   val scala210 = "2.10.6"
   val scala211 = "2.11.11"
   val scala212 = "2.12.3"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.16

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -17,3 +17,5 @@ addSbtPlugin("org.scala-native" % "sbt-crossproject" % "0.2.1")
 addSbtPlugin("org.scala-native" % "sbt-scalajs-crossproject" % "0.2.1")
 
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.2")
+
+addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")

--- a/readme/Changelog.scalatex
+++ b/readme/Changelog.scalatex
@@ -1,5 +1,14 @@
 @import Main._
 @sect{Change Log}
+    @sect{0.4.4}
+        @ul
+            @li
+                Scala Native support for the modules: @code{fastparse},
+                @code{scalaparse}, @code{pythonparse} and @code{cssparse}.
+                Porting to Scala Native required no diffs in the source code,
+                only build modifications. This release should be identical to
+                0.4.3.
+
     @sect{0.4.3}
         @ul
             @li


### PR DESCRIPTION
`+modules/publishSigned` will no longer work since native projects only cross-build against 2.11. sbt-doge solves this by making `very publishSigned` only run publishSigned for the defined crossScalaVersions in each project. However, the `modules` aggregate was messing up something so that the native modules were still being built against 2.10 with `very compile`. Removing `modules` fixed the problem.

While trying to debug the problems, I some changes to clean up build.sbt to better understand what was happening.