### PR TITLE
upgrade to latest utest (0.5.3)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ def macroDependencies(version: String) =
 val shared = Seq(
   libraryDependencies ++= macroDependencies(scalaVersion.value),
   libraryDependencies ++= Seq(
-    "com.lihaoyi" %%% "utest" % "0.4.8" % "test",
+    "com.lihaoyi" %%% "utest" % "0.5.3" % "test",
     "com.lihaoyi" %%% "sourcecode" % "0.1.4"
   ),
   scalaJSStage in Global := FullOptStage,

--- a/scalaparse/shared/src/test/scala/scalaparse/TestUtil.scala
+++ b/scalaparse/shared/src/test/scala/scalaparse/TestUtil.scala
@@ -1,6 +1,6 @@
 package scalaparse
 
-import utest.asserts.assert
+import utest.assert
 import fastparse.all._
 
 


### PR DESCRIPTION
this is needed for the Scala community build; fansi requires the
latest utest now, so anything else using utest must be
source-compatible with the latest utest too