### PR TITLE
Use a shallow clone in scalaparse ProjectTests

### DIFF
--- a/scalaparse/jvm/src/test/scala/scalaparse/ProjectTests.scala
+++ b/scalaparse/jvm/src/test/scala/scalaparse/ProjectTests.scala
@@ -60,7 +60,7 @@ object ProjectTests extends TestSuite{
         println("CLONING")
 
         new java.lang.ProcessBuilder()
-          .command("git", "clone", repo, path.toString)
+          .command("git", "clone", repo, path.toString, "--depth", "1")
           .directory(new java.io.File("."))
           .start()
           .waitFor()


### PR DESCRIPTION
I noticed that fastparse/target/repos is a disk hog in the community build.

This commit changes the checkout of third party repos by test cases to use a shallow clone,
as is already done in classparse/jvm/src/test/scala/classparse/ProjectTests.scala

References https://github.com/scala/community-builds/issues/617