### PR TITLE
use openjdk7 instead of oraclejdk7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     - env:
       - CI_SCRIPT: '"fastparseJVM/test; fastparseJS/test; fastparseByteJVM/test; fastparseByteJS/test"'
       scala: 2.10.6
-      jdk: oraclejdk7
+      jdk: openjdk7
     - env:
       - CI_SCRIPT: '"fastparseJVM/test; fastparseJS/test; fastparseByteJVM/test; fastparseByteJS/test"'
       scala: 2.11.11
@@ -46,7 +46,7 @@ matrix:
     - env:
       - CI_SCRIPT: '"classparseJVM/test; classparseJS/test"'
       scala: 2.10.6
-      jdk: oraclejdk7
+      jdk: openjdk7
     - env:
       - CI_SCRIPT: '"classparseJVM/test; classparseJS/test"'
       scala: 2.12.3
@@ -55,7 +55,7 @@ matrix:
     - env:
       - CI_SCRIPT: '"scalaparseJVM/test; scalaparseJS/test"'
       scala: 2.10.6
-      jdk: oraclejdk7
+      jdk: openjdk7
     - env:
       - CI_SCRIPT: '"scalaparseJVM/test; scalaparseJS/test"'
       scala: 2.12.3


### PR DESCRIPTION
travis-ci no longer support oraclejdk7 https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879


https://travis-ci.org/lihaoyi/fastparse/jobs/297130985#L427

```
$ jdk_switcher use oraclejdk7
Switching to Oracle JDK7 (java-7-oracle), JAVA_HOME will be set to /usr/lib/jvm/java-7-oracle
update-java-alternatives: directory does not exist: /usr/lib/jvm/java-7-oracle
```

https://travis-ci.org/lihaoyi/fastparse/jobs/297130985#L451

```
$ java -Xmx32m -version
java version "1.8.0_144"
Java(TM) SE Runtime Environment (build 1.8.0_144-b01)
Java HotSpot(TM) 64-Bit Server VM (build 25.144-b01, mixed mode)
$ javac -J-Xmx32m -version
javac 1.8.0_144
```