### PR TITLE
add collect method

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/core/ParserApi.scala
+++ b/fastparse/shared/src/main/scala/fastparse/core/ParserApi.scala
@@ -3,7 +3,7 @@ import acyclic.file
 import fastparse.core.Implicits._
 import fastparse.parsers.Combinators.{Capturing, Cut, Either, Logged, Not, Opaque, Optional, Repeat, Sequence}
 import fastparse.parsers.Terminals.Pass
-import fastparse.parsers.Transformers.{Filtered, FlatMapped, Mapper}
+import fastparse.parsers.Transformers.{Collected, Filtered, FlatMapped, Mapper}
 import fastparse.utils.ReprOps
 
 abstract class ParserApi[+T, Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) {
@@ -90,6 +90,12 @@ abstract class ParserApi[+T, Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) {
   def filter(predicate: T => Boolean): Parser[T, Elem, Repr]
 
   /**
+    * Transforms the result of this Parser with the given PartialFunction
+    * if it is defined and fails the parser if it's not
+    */
+  def collect[V](pf: PartialFunction[T, V]): Parser[V, Elem, Repr]
+
+  /**
    * alias for `filter`
    */
   final def withFilter(predicate: T => Boolean): Parser[T, Elem, Repr] = filter(predicate)
@@ -135,4 +141,6 @@ class ParserApiImpl[+T, Elem, Repr](self: Parser[T, Elem, Repr])
   def flatMap[V](f: T => Parser[V, Elem, Repr]): Parser[V, Elem, Repr] = FlatMapped(self, f)
 
   def filter(predicate: T => Boolean): Parser[T, Elem, Repr] = Filtered(self,predicate)
+
+  def collect[V](pf: PartialFunction[T, V]): Parser[V, Elem, Repr] = Collected(self, pf)
 }

--- a/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
@@ -215,6 +215,12 @@ object ExampleTests extends TestSuite{
         assert("""digits.filter\(.*\)$""".r.findPrefixOf(even.toString).isDefined)
         assert("""digits.filter\(.*\):1:1 ..."123"$""".r.findPrefixOf(failure.extra.traced.trace).isDefined)
       }
+      'collect - {
+        val p = PassWith(Option(42))
+        val Parsed.Success(r, _) = p.collect { case Some(x) => x }.parse("")
+        assert(r == 42)
+        val Parsed.Failure(_, _, _) = p.collect { case None => 42 }.parse("")
+      }
       'opaque - {
         val digit = CharIn('0' to '9')
         val letter = CharIn('A' to 'Z')


### PR DESCRIPTION
Hey,

It seems to me that if parsers support `filter` and `map`, they should also support `collect`, which is what this PR adds. Please consider merging it. 