### PR TITLE
change the order of the type parameters of core.Parser…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,7 +123,9 @@ lazy val fastparse = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .jvmSettings(fork in (Test, run) := true)
   .nativeSettings(nativeSettings)
 lazy val fastparseJS = fastparse.js
-lazy val fastparseJVM = fastparse.jvm
+lazy val fastparseJVM = fastparse.jvm.settings(
+  mimaPreviousArtifacts := Set("com.lihaoyi" %% "fastparse" % "1.0.0")
+)
 lazy val fastparseNative = fastparse.native
 
 lazy val fastparseByte = crossProject(JSPlatform, JVMPlatform, NativePlatform)

--- a/fastparse/shared/src/main/scala/fastparse/Api.scala
+++ b/fastparse/shared/src/main/scala/fastparse/Api.scala
@@ -40,22 +40,22 @@ abstract class Api[Elem, Repr](ct: ClassTag[Elem],
 
   type ParseCtx = core.ParseCtx[Elem, Repr]
   object Mutable{
-    type Success[T] = core.Mutable.Success[T, Elem, Repr]
+    type Success[T] = core.Mutable.Success[Elem, Repr, T]
     val Success = core.Mutable.Success
     type Failure = core.Mutable.Failure[Elem, Repr]
     val Failure = core.Mutable.Failure
   }
 
-  type Parsed[+T] = core.Parsed[T, Elem, Repr]
+  type Parsed[+T] = core.Parsed[Elem, Repr, T]
   object Parsed {
     type Failure = core.Parsed.Failure[Elem, Repr]
-    type Success[T] = core.Parsed.Success[T, Elem, Repr]
+    type Success[T] = core.Parsed.Success[Elem, Repr, T]
     val Success = core.Parsed.Success
     val Failure = core.Parsed.Failure
   }
 
   val Pass = parsers.Terminals.Pass[Elem, Repr]()
-  def PassWith[T](t: T) = parsers.Terminals.PassWith[T, Elem, Repr](t)
+  def PassWith[T](t: T) = parsers.Terminals.PassWith[Elem, Repr, T](t)
   val Fail = parsers.Terminals.Fail[Elem, Repr]()
   val Start = parsers.Terminals.Start[Elem, Repr]()
   val End = parsers.Terminals.End[Elem, Repr]()
@@ -92,7 +92,7 @@ abstract class Api[Elem, Repr](ct: ClassTag[Elem],
     parsers.Combinators.Rule(name.value, () => p)
 
   type P0 = Parser[Unit]
-  type Parser[+T] = core.Parser[T, Elem, Repr]
+  type Parser[+T] = core.Parser[Elem, Repr, T]
   type P[+T] = Parser[T]
   val ParseError = core.ParseError[Elem, Repr] _
   type ParseError = core.ParseError[Elem, Repr]

--- a/fastparse/shared/src/main/scala/fastparse/StringApi.scala
+++ b/fastparse/shared/src/main/scala/fastparse/StringApi.scala
@@ -56,7 +56,7 @@ class StringApi() extends Api[Char, String](
 }
 
 object all extends StringApi{
-  implicit def parserApi[T, V](p: T)(implicit c: T => core.Parser[V, Char, String]): ParserApi[V, Char, String] =
-    new ParserApiImpl[V, Char, String](p)
+  implicit def parserApi[T, V](p: T)(implicit c: T => core.Parser[Char, String, V]): ParserApi[Char, String, V] =
+    new ParserApiImpl[Char, String, V](p)
 }
 object noApi extends StringApi

--- a/fastparse/shared/src/main/scala/fastparse/WhitespaceApi.scala
+++ b/fastparse/shared/src/main/scala/fastparse/WhitespaceApi.scala
@@ -87,7 +87,7 @@ object WhitespaceApi {
  * provides replacement methods `repX` and `~~` if you wish to call the
  * original un-modified versions of these operators.
  */
-class WhitespaceApi[+T](p0: P[T], WL: P0) extends ParserApiImpl[T, Char, String](p0)  {
+class WhitespaceApi[+T](p0: P[T], WL: P0) extends ParserApiImpl[Char, String, T](p0)  {
 
 
   def repX[R](implicit ev: Repeater[T, R]): P[R] = Repeat(p0, 0, Int.MaxValue, Pass)

--- a/fastparse/shared/src/main/scala/fastparse/core/ParserApi.scala
+++ b/fastparse/shared/src/main/scala/fastparse/core/ParserApi.scala
@@ -12,34 +12,34 @@ abstract class ParserApi[+T, Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) {
    * Wraps this in a [[Logged]]. This prints out information
    * where a parser was tried and its result, which is useful for debugging
    */
-  def log(msg: String = toString)(implicit out: Logger): Parser[T, Elem, Repr]
+  def log(msg: String = toString)(implicit out: Logger): Parser[Elem, Repr, T]
 
   /**
    * Makes this parser opaque, i.e. hides it and its inner parsers
    * from the stack trace, providing the specified message instead.
    */
-  def opaque(msg: String = toString): Parser[T, Elem, Repr]
+  def opaque(msg: String = toString): Parser[Elem, Repr, T]
 
   /**
    * Repeats this parser 0 or more times
    */
-  def rep[R](implicit ev: Repeater[T, R]): Parser[R, Elem, Repr]
+  def rep[R](implicit ev: Repeater[T, R]): Parser[Elem, Repr, R]
   def rep[R](min: Int = 0,
-             sep: Parser[_, Elem, Repr] = Pass[Elem, Repr],
+             sep: Parser[Elem, Repr, _] = Pass[Elem, Repr],
              max: Int = Int.MaxValue,
              exactly: Int = -1)
-            (implicit ev: Repeater[T, R]): Parser[R, Elem, Repr]
+            (implicit ev: Repeater[T, R]): Parser[Elem, Repr, R]
 
   /**
    * Parses using this or the parser `p`
    */
-  def |[V >: T](p: Parser[V, Elem, Repr]): Parser[V, Elem, Repr]
+  def |[V >: T](p: Parser[Elem, Repr, V]): Parser[Elem, Repr, V]
 
   /**
    * Parses using this followed by the parser `p`
    */
-  def ~[V, R](p: Parser[V, Elem, Repr])
-             (implicit ev: Sequencer[T, V, R]): Parser[R, Elem, Repr]
+  def ~[V, R](p: Parser[Elem, Repr, V])
+             (implicit ev: Sequencer[T, V, R]): Parser[Elem, Repr, R]
 
   /**
    * Parses using this followed by the parser `p`, performing a Cut if
@@ -49,90 +49,90 @@ abstract class ParserApi[+T, Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) {
    * This lets you greatly narrow the error position by avoiding unwanted
    * backtracking.
    */
-  def ~/[V, R](p: Parser[V, Elem, Repr])
-              (implicit ev: Sequencer[T, V, R]): Parser[R, Elem, Repr]
+  def ~/[V, R](p: Parser[Elem, Repr, V])
+              (implicit ev: Sequencer[T, V, R]): Parser[Elem, Repr, R]
 
   /**
    * Performs a cut if this parses successfully.
    */
-  def ~/ : Parser[T, Elem, Repr]
+  def ~/ : Parser[Elem, Repr, T]
 
   /**
    * Parses this, optionally
    */
-  def ?[R](implicit ev: Optioner[T, R]): Parser[R, Elem, Repr]
+  def ?[R](implicit ev: Optioner[T, R]): Parser[Elem, Repr, R]
 
   /**
    * Wraps this in a [[Not]] for negative lookahead
    */
-  def unary_! : Parser[Unit, Elem, Repr]
+  def unary_! : Parser[Elem, Repr, Unit]
 
   /**
    * Used to capture the text parsed by this as a `String`
    */
-  def ! : Parser[Repr, Elem, Repr]
+  def ! : Parser[Elem, Repr, Repr]
 
   /**
    * Transforms the result of this Parser with the given function
    */
-  def map[V](f: T => V): Parser[V, Elem, Repr]
+  def map[V](f: T => V): Parser[Elem, Repr, V]
 
   /**
    * Uses the result of this parser to create another parser that
    * will be used for the next parse
    */
-  def flatMap[V](f: T => Parser[V, Elem, Repr]): Parser[V, Elem, Repr]
+  def flatMap[V](f: T => Parser[Elem, Repr, V]): Parser[Elem, Repr, V]
 
   /**
    * applies the supplied predicate to the current parser succeeding
      on true failing on false
    */
-  def filter(predicate: T => Boolean): Parser[T, Elem, Repr]
+  def filter(predicate: T => Boolean): Parser[Elem, Repr, T]
 
   /**
    * alias for `filter`
    */
-  final def withFilter(predicate: T => Boolean): Parser[T, Elem, Repr] = filter(predicate)
+  final def withFilter(predicate: T => Boolean): Parser[Elem, Repr, T] = filter(predicate)
 }
 
-class ParserApiImpl[+T, Elem, Repr](self: Parser[T, Elem, Repr])
+class ParserApiImpl[+T, Elem, Repr](self: Parser[Elem, Repr, T])
                                        (implicit repr: ReprOps[Elem, Repr])
-    extends ParserApi[T, Elem, Repr] {
+    extends ParserApi[Elem, Repr, T] {
 
   def log(msg: String = self.toString)(implicit output: Logger) = Logged(self, msg, output.f)
 
   def opaque(msg: String = self.toString) = Opaque(self, msg)
 
-  def rep[R](implicit ev: Repeater[T, R]): Parser[R, Elem, Repr] =
+  def rep[R](implicit ev: Repeater[T, R]): Parser[Elem, Repr, R] =
     Repeat(self, 0, Int.MaxValue, Pass[Elem, Repr])
-  def rep[R](min: Int = 0, sep: Parser[_, Elem, Repr] = Pass[Elem, Repr],
+  def rep[R](min: Int = 0, sep: Parser[Elem, Repr, _] = Pass[Elem, Repr],
              max: Int = Int.MaxValue, exactly: Int = -1)
-            (implicit ev: Repeater[T, R]): Parser[R, Elem, Repr] = {
+            (implicit ev: Repeater[T, R]): Parser[Elem, Repr, R] = {
     if (exactly < 0)
       Repeat(self, min, max, sep)
     else
       Repeat(self, exactly, exactly, sep)
   }
 
-  def |[V >: T](p: Parser[V, Elem, Repr]): Parser[V, Elem, Repr] =
-    Either[V, Elem, Repr](Either.flatten(Vector(self, p)):_*)
+  def |[V >: T](p: Parser[Elem, Repr, V]): Parser[Elem, Repr, V] =
+    Either[Elem, Repr, V](Either.flatten(Vector(self, p)):_*)
 
-  def ~[V, R](p: Parser[V, Elem, Repr])(implicit ev: Sequencer[T, V, R]): Parser[R, Elem, Repr] =
-    Sequence.flatten(Sequence(self, p, cut=false).asInstanceOf[Sequence[R, R, R, Elem, Repr]])
-  def ~/[V, R](p: Parser[V, Elem, Repr])(implicit ev: Sequencer[T, V, R]): Parser[R, Elem, Repr] =
-    Sequence.flatten(Sequence(self, p, cut=true).asInstanceOf[Sequence[R, R, R, Elem, Repr]])
+  def ~[V, R](p: Parser[Elem, Repr, V])(implicit ev: Sequencer[T, V, R]): Parser[Elem, Repr, R] =
+    Sequence.flatten(Sequence(self, p, cut=false).asInstanceOf[Sequence[Elem, Repr, R, R, R]])
+  def ~/[V, R](p: Parser[Elem, Repr, V])(implicit ev: Sequencer[T, V, R]): Parser[Elem, Repr, R] =
+    Sequence.flatten(Sequence(self, p, cut=true).asInstanceOf[Sequence[Elem, Repr, R, R, R]])
 
-  def ?[R](implicit ev: Optioner[T, R]): Parser[R, Elem, Repr] = Optional(self)
+  def ?[R](implicit ev: Optioner[T, R]): Parser[Elem, Repr, R] = Optional(self)
 
-  def unary_! : Parser[Unit, Elem, Repr] = Not(self)
+  def unary_! : Parser[Elem, Repr, Unit] = Not(self)
 
-  def ~/ : Parser[T, Elem, Repr] = Cut[T, Elem, Repr](self)
+  def ~/ : Parser[Elem, Repr, T] = Cut[Elem, Repr, T](self)
 
-  def ! : Parser[Repr, Elem, Repr] = Capturing(self)
+  def ! : Parser[Elem, Repr, Repr] = Capturing(self)
 
-  def map[V](f: T => V): Parser[V, Elem, Repr] = Mapper(self, f)
+  def map[V](f: T => V): Parser[Elem, Repr, V] = Mapper(self, f)
 
-  def flatMap[V](f: T => Parser[V, Elem, Repr]): Parser[V, Elem, Repr] = FlatMapped(self, f)
+  def flatMap[V](f: T => Parser[Elem, Repr, V]): Parser[Elem, Repr, V] = FlatMapped(self, f)
 
-  def filter(predicate: T => Boolean): Parser[T, Elem, Repr] = Filtered(self,predicate)
+  def filter(predicate: T => Boolean): Parser[Elem, Repr, T] = Filtered(self,predicate)
 }

--- a/fastparse/shared/src/main/scala/fastparse/core/ParserApi.scala
+++ b/fastparse/shared/src/main/scala/fastparse/core/ParserApi.scala
@@ -6,7 +6,7 @@ import fastparse.parsers.Terminals.Pass
 import fastparse.parsers.Transformers.{Filtered, FlatMapped, Mapper}
 import fastparse.utils.ReprOps
 
-abstract class ParserApi[+T, Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) {
+abstract class ParserApi[Elem, Repr, +T]()(implicit repr: ReprOps[Elem, Repr]) {
 
   /**
    * Wraps this in a [[Logged]]. This prints out information
@@ -95,7 +95,7 @@ abstract class ParserApi[+T, Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) {
   final def withFilter(predicate: T => Boolean): Parser[Elem, Repr, T] = filter(predicate)
 }
 
-class ParserApiImpl[+T, Elem, Repr](self: Parser[Elem, Repr, T])
+class ParserApiImpl[Elem, Repr, +T](self: Parser[Elem, Repr, T])
                                        (implicit repr: ReprOps[Elem, Repr])
     extends ParserApi[Elem, Repr, T] {
 

--- a/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
+++ b/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
@@ -27,15 +27,15 @@ sealed trait Parsed[+T, Elem, Repr]{
    * Converts this instance of [[Parsed]] into a [[Parsed.Success]] or
    * throws an exception if it was a failure.
    */
-  def get: Parsed.Success[T, Elem, Repr] = this match{
-    case s: Parsed.Success[T, Elem, Repr] => s
+  def get: Parsed.Success[Elem, Repr, T] = this match{
+    case s: Parsed.Success[Elem, Repr, T] => s
     case f: Parsed.Failure[Elem, Repr] => throw new ParseError[Elem, Repr](f)
   }
 
   /**
     * Returns the result of $onSuccess if the parsing is successful, otherwise it returns the result of $onFailure
     */
-  def fold[X](onFailure: (Parser[_, Elem, Repr], Int, Parsed.Failure.Extra[Elem, Repr]) => X, onSuccess: (T, Int) => X): X = this match {
+  def fold[X](onFailure: (Parser[Elem, Repr, _], Int, Parsed.Failure.Extra[Elem, Repr]) => X, onSuccess: (T, Int) => X): X = this match {
     case Parsed.Success(t, i) => onSuccess(t, i)
     case f: Parsed.Failure[Elem, Repr] => onFailure(f.lastParser, f.index, f.extra)
   }
@@ -58,7 +58,7 @@ object Parsed {
    * @param index The index where the parse completed; may be less than
    *              the length of input
    */
-  case class Success[+T, Elem, Repr](value: T, index: Int) extends Parsed[T, Elem, Repr]
+  case class Success[+T, Elem, Repr](value: T, index: Int) extends Parsed[Elem, Repr, T]
 
   /**
    * Simple information about a parse failure. Also contains the original parse
@@ -71,9 +71,9 @@ object Parsed {
    * @param extra Extra supplementary information (including trace information).
    *              For details see [[Parsed.Failure.Extra]]
    */
-  case class Failure[Elem, Repr](lastParser: Parser[_, Elem, Repr],
+  case class Failure[Elem, Repr](lastParser: Parser[Elem, Repr, _],
                                  index: Int,
-                                 extra: Failure.Extra[Elem, Repr]) extends Parsed[Nothing, Elem, Repr]{
+                                 extra: Failure.Extra[Elem, Repr]) extends Parsed[Elem, Repr, Nothing]{
 
     def msg = Failure.formatStackTrace(
       Nil, extra.input, index, Failure.formatParser(lastParser, extra.input, index)
@@ -96,8 +96,8 @@ object Parsed {
 
     object Extra{
       class Impl[Elem, Repr](val input: ParserInput[Elem, Repr],
-                             startParser: Parser[_, Elem, Repr], startIndex: Int,
-                             lastParser: Parser[_, Elem, Repr], index: Int) extends Extra[Elem, Repr] {
+                             startParser: Parser[Elem, Repr, _], startIndex: Int,
+                             lastParser: Parser[Elem, Repr, _], index: Int) extends Extra[Elem, Repr] {
 
         lazy val traced = {
           input.checkTraceable()
@@ -148,7 +148,7 @@ object Parsed {
   case class TracedFailure[Elem, Repr](input: ParserInput[Elem, Repr],
                                        index: Int,
                                        fullStack: Vector[Frame],
-                                       traceParsers: Set[Parser[_, Elem, Repr]]) {
+                                       traceParsers: Set[Parser[Elem, Repr, _]]) {
 
     private[this] lazy val expected0 = new Precedence {
       def opPred = if (traceParsers.size == 1) traceParsers.head.opPred else Precedence.|
@@ -180,7 +180,7 @@ object Parsed {
   }
   object TracedFailure{
     def apply[Elem, Repr](input: ParserInput[Elem, Repr], index: Int,
-                          lastParser: Parser[_, Elem, Repr], traceData: (Int, Parser[_, Elem, Repr])) = {
+                          lastParser: Parser[Elem, Repr, _], traceData: (Int, Parser[Elem, Repr, _])) = {
       val (originalIndex, originalParser) = traceData
 
       val mutFailure = originalParser.parseRec(
@@ -207,7 +207,7 @@ trait Mutable[+T, Elem, Repr]{
    * Snapshots this mutable result and converts it into
    * an immutable [[Parsed]] object
    */
-  def toResult: Parsed[T, Elem, Repr]
+  def toResult: Parsed[Elem, Repr, T]
 
   /**
    * A set of parsers which have failed to parse at
@@ -215,7 +215,7 @@ trait Mutable[+T, Elem, Repr]{
    * at any particular index, what parsers could have
    * succeeded.
    */
-  def traceParsers: Set[Parser[_, Elem, Repr]]
+  def traceParsers: Set[Parser[Elem, Repr, _]]
 
   /**
    * Whether or not the parser encountered a Cut before reaching
@@ -240,8 +240,8 @@ object Mutable{
    */
   case class Success[T, Elem, Repr](var value: T,
                                     var index: Int,
-                                    var traceParsers: Set[Parser[_, Elem, Repr]],
-                                    var cut: Boolean = false) extends Mutable[T, Elem, Repr]{
+                                    var traceParsers: Set[Parser[Elem, Repr, _]],
+                                    var cut: Boolean = false) extends Mutable[Elem, Repr, T]{
 
     override def toString = s"Success($value, $index)"
     def toResult = Parsed.Success(value, index)
@@ -267,12 +267,12 @@ object Mutable{
   case class Failure[Elem, Repr](var input: ParserInput[Elem, Repr],
                                  fullStack: mutable.Buffer[Frame],
                                  var index: Int,
-                                 var lastParser: Parser[_, Elem, Repr],
-                                 originalParser: Parser[_, Elem, Repr],
+                                 var lastParser: Parser[Elem, Repr, _],
+                                 originalParser: Parser[Elem, Repr, _],
                                  originalIndex: Int,
                                  traceIndex: Int,
-                                 var traceParsers: Set[Parser[_, Elem, Repr]],
-                                 var cut: Boolean) extends Mutable[Nothing, Elem, Repr]{
+                                 var traceParsers: Set[Parser[Elem, Repr, _]],
+                                 var cut: Boolean) extends Mutable[Elem, Repr, Nothing]{
     def toResult = {
       val extra = new Parsed.Failure.Extra.Impl(input, originalParser, originalIndex, lastParser, index)
       Parsed.Failure(lastParser, index, extra)
@@ -295,9 +295,9 @@ object Mutable{
 case class ParseCtx[Elem, Repr](input: ParserInput[Elem, Repr],
                                 var logDepth: Int,
                                 traceIndex: Int,
-                                originalParser: Parser[_, Elem, Repr],
+                                originalParser: Parser[Elem, Repr, _],
                                 originalIndex: Int,
-                                instrument: (Parser[_, Elem, Repr], Int, () => Parsed[_, Elem, Repr]) => Unit,
+                                instrument: (Parser[Elem, Repr, _], Int, () => Parsed[Elem, Repr, _]) => Unit,
                                 var isFork: Boolean,
                                 var isCapturing: Boolean,
                                 var isNoCut: Boolean) {
@@ -307,7 +307,7 @@ case class ParseCtx[Elem, Repr](input: ParserInput[Elem, Repr],
     input, mutable.Buffer(), 0, null, originalParser,
     originalIndex, traceIndex, Set.empty, false
   )
-  val success = Mutable.Success[Any, Elem, Repr](null, 0, Set.empty, false)
+  val success = Mutable.Success[Elem, Repr, Any](null, 0, Set.empty, false)
 
   def checkForDrop(outerCut: Boolean) = !isCapturing && ((outerCut && !isNoCut) || !isFork)
 }
@@ -324,14 +324,14 @@ case class ParseCtx[Elem, Repr](input: ParserInput[Elem, Repr],
  * to make things faster but any 10%, whether or not you activate tracing.
  */
 abstract class Parser[+T, Elem, Repr]()(implicit val reprOps: ReprOps[Elem, Repr])
-  extends ParserResults[T, Elem, Repr] with Precedence{
+  extends ParserResults[Elem, Repr, T] with Precedence{
 
   /**
     * Can be passed into a `.parse` call to let you inject logic around
     * the parsing of top-level parsers, e.g. for logging and debugging.
     */
   type InstrumentCallback = (
-    (Parser[_, Elem, Repr], Int, () => Parsed[_, Elem, Repr]) => Unit
+    (Parser[Elem, Repr, _], Int, () => Parsed[Elem, Repr, _]) => Unit
   )
 
   /**
@@ -354,7 +354,7 @@ abstract class Parser[+T, Elem, Repr]()(implicit val reprOps: ReprOps[Elem, Repr
   def parse(input: Repr,
             index: Int = 0,
             instrument: InstrumentCallback = null)
-      : Parsed[T, Elem, Repr] = {
+      : Parsed[Elem, Repr, T] = {
     parseInput(IndexedParserInput(input), index, instrument)
   }
 
@@ -362,7 +362,7 @@ abstract class Parser[+T, Elem, Repr]()(implicit val reprOps: ReprOps[Elem, Repr
                     index: Int = 0,
                     instrument: InstrumentCallback = null)
                    (implicit ct: ClassTag[Elem])
-      : Parsed[T, Elem, Repr] = {
+      : Parsed[Elem, Repr, T] = {
     parseInput(IteratorParserInput(input), index, instrument)
   }
 
@@ -370,7 +370,7 @@ abstract class Parser[+T, Elem, Repr]()(implicit val reprOps: ReprOps[Elem, Repr
                  index: Int = 0,
                  instrument: InstrumentCallback = null)
 
-      : Parsed[T, Elem, Repr] = {
+      : Parsed[Elem, Repr, T] = {
     parseRec(
       new ParseCtx(input, 0, -1, this, index, instrument, false, false, false),
       index
@@ -399,7 +399,7 @@ abstract class Parser[+T, Elem, Repr]()(implicit val reprOps: ReprOps[Elem, Repr
   /**
    * Parses the given `input` starting from the given `index` and `logDepth`
    */
-  def parseRec(cfg: ParseCtx[Elem, Repr], index: Int): Mutable[T, Elem, Repr]
+  def parseRec(cfg: ParseCtx[Elem, Repr], index: Int): Mutable[Elem, Repr, T]
 
   /**
    * Whether or not this parser should show up when
@@ -420,9 +420,9 @@ abstract class Parser[+T, Elem, Repr]()(implicit val reprOps: ReprOps[Elem, Repr
 /**
  * Convenience methods to be used internally inside [[Parser]]s
  */
-trait ParserResults[+T, Elem, Repr]{ this: Parser[T, Elem, Repr] =>
-  def mergeTrace(traceIndex: Int, lhs: Set[Parser[_, Elem, Repr]],
-                 rhs: Set[Parser[_, Elem, Repr]]): Set[Parser[_, Elem, Repr]] = {
+trait ParserResults[+T, Elem, Repr]{ this: Parser[Elem, Repr, T] =>
+  def mergeTrace(traceIndex: Int, lhs: Set[Parser[Elem, Repr, _]],
+                 rhs: Set[Parser[Elem, Repr, _]]): Set[Parser[Elem, Repr, _]] = {
     if (traceIndex != -1) lhs | rhs
     else Set.empty
   }
@@ -439,7 +439,7 @@ trait ParserResults[+T, Elem, Repr]{ this: Parser[T, Elem, Repr] =>
    */
   def fail(f: Mutable.Failure[Elem, Repr],
            index: Int,
-           traceParsers: Set[Parser[_, Elem, Repr]] = null,
+           traceParsers: Set[Parser[Elem, Repr, _]] = null,
            cut: Boolean = false) = {
     f.index = index
     f.cut = cut
@@ -473,7 +473,7 @@ trait ParserResults[+T, Elem, Repr]{ this: Parser[T, Elem, Repr] =>
   def failMore(f: Mutable.Failure[Elem, Repr],
                index: Int,
                logDepth: Int,
-               traceParsers: Set[Parser[_, Elem, Repr]] = null,
+               traceParsers: Set[Parser[Elem, Repr, _]] = null,
                cut: Boolean = false): Mutable.Failure[Elem, Repr] = {
 
     if (f.traceIndex != -1) {
@@ -504,12 +504,12 @@ trait ParserResults[+T, Elem, Repr]{ this: Parser[T, Elem, Repr] =>
    *                     reported to ensure proper error reporting.
    * @param cut Whether the parse crossed a cut and should prevent backtracking
    */
-  def success[T](s: Mutable.Success[_, Elem, Repr],
+  def success[T](s: Mutable.Success[Elem, Repr, _],
                  value: T,
                  index: Int,
-                 traceParsers: Set[Parser[_, Elem, Repr]],
+                 traceParsers: Set[Parser[Elem, Repr, _]],
                  cut: Boolean) = {
-    val s1 = s.asInstanceOf[Mutable.Success[T, Elem, Repr]]
+    val s1 = s.asInstanceOf[Mutable.Success[Elem, Repr, T]]
 
     s1.value = value
     s1.index = index

--- a/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
+++ b/fastparse/shared/src/main/scala/fastparse/core/Parsing.scala
@@ -17,7 +17,7 @@ case class Frame(index: Int, parser: Parser[_, _, _])
 /**
  * Result of a parse, whether successful or failed.
  */
-sealed trait Parsed[+T, Elem, Repr]{
+sealed trait Parsed[Elem, Repr, +T]{
   /**
    * Where the parser ended up, whether the result was a success or failure
    */
@@ -58,7 +58,7 @@ object Parsed {
    * @param index The index where the parse completed; may be less than
    *              the length of input
    */
-  case class Success[+T, Elem, Repr](value: T, index: Int) extends Parsed[Elem, Repr, T]
+  case class Success[Elem, Repr, +T](value: T, index: Int) extends Parsed[Elem, Repr, T]
 
   /**
    * Simple information about a parse failure. Also contains the original parse
@@ -202,7 +202,7 @@ object Parsed {
  * An internal mirror of the [[Parsed]] classes, except it contains far
  * more data and is mutable to maximize performance
  */
-trait Mutable[+T, Elem, Repr]{
+trait Mutable[Elem, Repr, +T]{
   /**
    * Snapshots this mutable result and converts it into
    * an immutable [[Parsed]] object
@@ -238,7 +238,7 @@ object Mutable{
    * @param cut Whether or not this parser crossed a cut and can not longer
    *            backtrack
    */
-  case class Success[T, Elem, Repr](var value: T,
+  case class Success[Elem, Repr, T](var value: T,
                                     var index: Int,
                                     var traceParsers: Set[Parser[Elem, Repr, _]],
                                     var cut: Boolean = false) extends Mutable[Elem, Repr, T]{
@@ -323,7 +323,7 @@ case class ParseCtx[Elem, Repr](input: ParserInput[Elem, Repr],
  * [[parsers.Combinators.Sequence.Flat]]s. These optimizations together appear
  * to make things faster but any 10%, whether or not you activate tracing.
  */
-abstract class Parser[+T, Elem, Repr]()(implicit val reprOps: ReprOps[Elem, Repr])
+abstract class Parser[Elem, Repr, +T]()(implicit val reprOps: ReprOps[Elem, Repr])
   extends ParserResults[Elem, Repr, T] with Precedence{
 
   /**
@@ -420,7 +420,7 @@ abstract class Parser[+T, Elem, Repr]()(implicit val reprOps: ReprOps[Elem, Repr
 /**
  * Convenience methods to be used internally inside [[Parser]]s
  */
-trait ParserResults[+T, Elem, Repr]{ this: Parser[Elem, Repr, T] =>
+trait ParserResults[Elem, Repr, +T]{ this: Parser[Elem, Repr, T] =>
   def mergeTrace(traceIndex: Int, lhs: Set[Parser[Elem, Repr, _]],
                  rhs: Set[Parser[Elem, Repr, _]]): Set[Parser[Elem, Repr, _]] = {
     if (traceIndex != -1) lhs | rhs

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
@@ -45,7 +45,7 @@ object Combinators {
   /**
    * Wrap a parser in this if you don't want for it to show up in a stack trace
    */
-  case class NoTrace[T, Elem, Repr](p: Parser[Elem, Repr, T])
+  case class NoTrace[Elem, Repr, T](p: Parser[Elem, Repr, T])
                                    (implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, T]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
       p.parseRec(cfg, index) match {
@@ -67,7 +67,7 @@ object Combinators {
    *
    * @param msg The message for the wrapper
    */
-  case class Opaque[+T, Elem, Repr](p: Parser[Elem, Repr, T], msg: String)
+  case class Opaque[Elem, Repr, +T](p: Parser[Elem, Repr, T], msg: String)
                                    (implicit repr: ReprOps[Elem, Repr])
     extends Parser[Elem, Repr, T]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
@@ -88,7 +88,7 @@ object Combinators {
   /**
    *
    */
-  case class NoCut[T, Elem, Repr](p: Parser[Elem, Repr, T])
+  case class NoCut[Elem, Repr, T](p: Parser[Elem, Repr, T])
                                  (implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, T]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
       val oldNoCut = cfg.isNoCut
@@ -111,7 +111,7 @@ object Combinators {
    * Wraps a parser and prints out the indices where it starts
    * and ends, together with its result
    */
-  case class Logged[+T, Elem, Repr](p: Parser[Elem, Repr, T],
+  case class Logged[Elem, Repr, +T](p: Parser[Elem, Repr, T],
                                     msg: String, output: String => Unit)
                                    (implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, T]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
@@ -149,7 +149,7 @@ object Combinators {
    * [[p]] only when `parse` is called to allow for circular
    * dependencies between parsers.
    */
-  case class Rule[+T, Elem, Repr](name: String, p: () => Parser[Elem, Repr, T])
+  case class Rule[Elem, Repr, +T](name: String, p: () => Parser[Elem, Repr, T])
                                  (implicit repr: ReprOps[Elem, Repr])
     extends Parser[Elem, Repr, T]{
     private[this] lazy val pCached = p()
@@ -223,7 +223,7 @@ object Combinators {
    * Wraps a parser and succeeds with `Some` if [[p]] succeeds,
    * and succeeds with `None` if [[p]] fails.
    */
-  case class Optional[+T, R, Elem, Repr](p: Parser[Elem, Repr, T])
+  case class Optional[Elem, Repr, +T, R](p: Parser[Elem, Repr, T])
                                         (implicit ev: Implicits.Optioner[T, R],
                                          repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, R]{
 
@@ -262,10 +262,10 @@ object Combinators {
     /**
      * The contents of a [[Sequence]] node, minus the left subtree.
      */
-    case class Chain[R, Elem, Repr](p: Parser[Elem, Repr, R], cut: Boolean)
+    case class Chain[Elem, Repr, R](p: Parser[Elem, Repr, R], cut: Boolean)
                                    (val ev: Implicits.Sequencer[R, R, R])
 
-    case class Flat[R, Elem, Repr](p0: Parser[Elem, Repr, R],
+    case class Flat[Elem, Repr, R](p0: Parser[Elem, Repr, R],
                                    ps: ArrayBuffer[Chain[Elem, Repr, R]])
                                   (implicit repr: ReprOps[Elem, Repr])
       extends Parser[Elem, Repr, R] {
@@ -358,8 +358,8 @@ object Combinators {
    * Parsers two things in a row, returning a tuple of the two
    * results if both things succeed
    */
-  case class Sequence[+T1, +T2, R,
-                      Elem, Repr](p1: Parser[Elem, Repr, T1],
+  case class Sequence[Elem, Repr,
+                      +T1, +T2, R](p1: Parser[Elem, Repr, T1],
                                   p2: Parser[Elem, Repr, T2], cut: Boolean)
                                  (implicit ev: Implicits.Sequencer[T1, T2, R],
                                   repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, R]{
@@ -403,7 +403,7 @@ object Combinators {
   }
 
 
-  case class Cut[T, Elem, Repr](p: Parser[Elem, Repr, T])
+  case class Cut[Elem, Repr, T](p: Parser[Elem, Repr, T])
                                (implicit repr: ReprOps[Elem, Repr])extends Parser[Elem, Repr, T]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
       p.parseRec(cfg, index) match{
@@ -423,7 +423,7 @@ object Combinators {
    * The range [[min]] and [[max]] bounds are inclusive.
    * It uses the [[delimiter]] parser between parses and discards its results.
    */
-  case class Repeat[T, +R, Elem, Repr](p: Parser[Elem, Repr, T], min: Int, max: Int,
+  case class Repeat[Elem, Repr, T, +R](p: Parser[Elem, Repr, T], min: Int, max: Int,
                                        delimiter: Parser[Elem, Repr, _])
                                       (implicit ev: Implicits.Repeater[T, R],
                                        repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, R]{
@@ -510,7 +510,7 @@ object Combinators {
    * Parses using one parser or the other, if the first one fails. Returns
    * the first one that succeeds and fails if both fail
    */
-  case class Either[T, Elem, Repr](ps: Parser[T, Elem, Repr]*)
+  case class Either[Elem, Repr, T](ps: Parser[T, Elem, Repr]*)
                                   (implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, T]{
     private[this] val ps0 = ps.toArray
     private[this] val n = ps0.length

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Combinators.scala
@@ -337,7 +337,7 @@ object Combinators {
      * A ~ B ~ C ~ D
      * ((A ~ B) ~ C) ~ D
      */
-    def flatten[R, Elem, Repr](s: Sequence[Elem, Repr, R, R, R])
+    def flatten[Elem, Repr, R](s: Sequence[Elem, Repr, R, R, R])
                               (implicit repr: ReprOps[Elem, Repr]): Flat[Elem, Repr, R] = {
       def rec(s: Sequence[Elem, Repr, R, R, R]): Flat[Elem, Repr, R] = {
         val ev2 = s.ev2.asInstanceOf[Implicits.Sequencer[R, R, R]]
@@ -501,7 +501,7 @@ object Combinators {
   }
 
   object Either{
-    def flatten[T, Elem, Repr](p: Vector[Parser[Elem, Repr, T]]): Vector[Parser[Elem, Repr, T]] = p.flatMap{
+    def flatten[Elem, Repr, T](p: Vector[Parser[Elem, Repr, T]]): Vector[Parser[Elem, Repr, T]] = p.flatMap{
       case Either(ps@_*) => ps
       case p => Vector(p)
     }
@@ -510,7 +510,7 @@ object Combinators {
    * Parses using one parser or the other, if the first one fails. Returns
    * the first one that succeeds and fails if both fail
    */
-  case class Either[Elem, Repr, T](ps: Parser[T, Elem, Repr]*)
+  case class Either[Elem, Repr, T](ps: Parser[Elem, Repr, T]*)
                                   (implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, T]{
     private[this] val ps0 = ps.toArray
     private[this] val n = ps0.length

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Intrinsics.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Intrinsics.scala
@@ -96,7 +96,7 @@ object Intrinsics {
                                 (implicit repr: ReprOps[Elem, Repr],
                                  helper: ElemSetHelper[Elem],
                                  ordering: Ordering[Elem])
-      extends Parser[Unit, Elem, Repr] {
+      extends Parser[Elem, Repr, Unit] {
 
     private[this] val trie = new TrieNode[Elem](strings.map(repr.toArray(_): IndexedSeq[Elem]), ignoreCase)
 
@@ -132,7 +132,7 @@ object Intrinsics {
 
     s"$name(${repr.literalize(repr.flatten(strings.map(repr.fromSeq)))})"
   }
-  trait WhileParser[Elem, Repr] extends Parser[Unit, Elem, Repr]{
+  trait WhileParser[Elem, Repr] extends Parser[Elem, Repr, Unit]{
     def check(e: Elem): Boolean
     def min: Int
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
@@ -148,7 +148,7 @@ object Intrinsics {
   abstract class PrecomputableParser[Elem, Repr](generatorOrPred: GenOrPred[Elem])
                                                 (implicit val helper: ElemSetHelper[Elem],
                                                  val repr: ReprOps[Elem, Repr])
-    extends Parser[Unit, Elem, Repr]{
+    extends Parser[Elem, Repr, Unit]{
 
     private[this] val uberSet: Utils.BitSet[Elem] = generatorOrPred match{
       case Left(generator) => BitSet(generator)

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Terminals.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Terminals.scala
@@ -24,7 +24,7 @@ object Terminals {
   /**
     * A parser that always succeeds with given result value `t`, consuming no input
     */
-  case class PassWith[T, Elem, Repr](t: T)(implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, T]{
+  case class PassWith[Elem, Repr, T](t: T)(implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, T]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = success(cfg.success, t, index, Set.empty, false)
   }
 

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Terminals.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Terminals.scala
@@ -16,7 +16,7 @@ object Terminals {
   /**
    * A parser that always succeeds, consuming no input
    */
-  case class Pass[Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) extends Parser[Unit, Elem, Repr]{
+  case class Pass[Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, Unit]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = success(cfg.success, (), index, Set.empty, false)
     override val toString = "Pass"
   }
@@ -24,21 +24,21 @@ object Terminals {
   /**
     * A parser that always succeeds with given result value `t`, consuming no input
     */
-  case class PassWith[T, Elem, Repr](t: T)(implicit repr: ReprOps[Elem, Repr]) extends Parser[T, Elem, Repr]{
+  case class PassWith[T, Elem, Repr](t: T)(implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, T]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = success(cfg.success, t, index, Set.empty, false)
   }
 
   /**
    * A parser that always fails immediately
    */
-  case class Fail[Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) extends Parser[Nothing, Elem, Repr]{
+  case class Fail[Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, Nothing]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = fail(cfg.failure, index)
     override val toString = "Fail"
   }
   /**
    * Succeeds, consuming a single element
    */
-  case class AnyElem[Elem, Repr](name: String)(implicit repr: ReprOps[Elem, Repr]) extends Parser[Unit, Elem, Repr]{
+  case class AnyElem[Elem, Repr](name: String)(implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, Unit]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
       val input = cfg.input
       if (!input.isReachable(index)) fail(cfg.failure, index)
@@ -49,7 +49,7 @@ object Terminals {
   /**
    * Consumes up to `count` elements, if they are available
    */
-  case class AnyElems[Elem, Repr](name: String, count: Int)(implicit repr: ReprOps[Elem, Repr]) extends Parser[Unit, Elem, Repr]{
+  case class AnyElems[Elem, Repr](name: String, count: Int)(implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, Unit]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
       val input = cfg.input
       if (!input.isReachable(index + count - 1)) fail(cfg.failure, index)
@@ -62,7 +62,7 @@ object Terminals {
    * Succeeds if at the start of the input, consuming no input
    */
 
-  case class Start[Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) extends Parser[Unit, Elem, Repr]{
+  case class Start[Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, Unit]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
       if (index == 0) success(cfg.success, (), index, Set.empty, false)
       else fail(cfg.failure, index)
@@ -73,7 +73,7 @@ object Terminals {
   /**
    * Succeeds if at the end of the input, consuming no input
    */
-  case class End[Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) extends Parser[Unit, Elem, Repr]{
+  case class End[Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, Unit]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
       if (!cfg.input.isReachable(index)) success(cfg.success, (), index, Set.empty, false)
       else fail(cfg.failure, index)
@@ -116,7 +116,7 @@ object Terminals {
    */
   case class Literal[Elem, Repr](s: Repr)
                                 (implicit repr: ReprOps[Elem, Repr])
-       extends Parser[Unit, Elem, Repr]{
+       extends Parser[Elem, Repr, Unit]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
 
       if (startsWith(cfg.input, s, index)) success(cfg.success, (), index + repr.length(s), Set.empty, false)
@@ -130,7 +130,7 @@ object Terminals {
    */
   case class IgnoreCase(s: IndexedSeq[Char])
                        (implicit repr: ReprOps[Char, String])
-       extends Parser[Unit, Char, String](){
+       extends Parser[Char, String, Unit](){
 
     def parseRec(cfg: ParseCtx[Char, String], index: Int) = {
       if (startsWithIgnoreCase(cfg.input, s, index)) success(cfg.success, (), index + s.length, Set.empty, false)
@@ -144,7 +144,7 @@ object Terminals {
    */
   case class ElemLiteral[Elem, Repr](c: Elem)
                                     (implicit repr: ReprOps[Elem, Repr])
-       extends Parser[Unit, Elem, Repr]{
+       extends Parser[Elem, Repr, Unit]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
       val input = cfg.input
       if (!input.isReachable(index)) fail(cfg.failure, index)
@@ -159,7 +159,7 @@ object Terminals {
    * parse into the input. e.g. useful for providing
    * source locations for AST nodes. Consumes no input.
    */
-  case class Index[Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) extends Parser[Int, Elem, Repr]{
+  case class Index[Elem, Repr]()(implicit repr: ReprOps[Elem, Repr]) extends Parser[Elem, Repr, Int]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
       success(cfg.success, index, index, Set.empty, false)
     }

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Transformers.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Transformers.scala
@@ -12,25 +12,25 @@ object Transformers {
   /**
    * Applies a transformation [[f]] to the result of [[p]]
    */
-  case class Mapper[T, V, Elem, Repr](p: Parser[T, Elem, Repr], f: T => V)
+  case class Mapper[T, V, Elem, Repr](p: Parser[Elem, Repr, T], f: T => V)
                                      (implicit repr: ReprOps[Elem, Repr])
-    extends Parser[V, Elem, Repr]{
+    extends Parser[Elem, Repr, V]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
       p.parseRec(cfg, index) match{
-        case s: Mutable.Success[T, Elem, Repr] => success(s, f(s.value), s.index, s.traceParsers, s.cut)
+        case s: Mutable.Success[Elem, Repr, T] => success(s, f(s.value), s.index, s.traceParsers, s.cut)
         case f: Mutable.Failure[Elem, Repr] => failMore(f, index, cfg.logDepth)
       }
     }
     override def toString = p.toString
   }
 
-  case class FlatMapped[T, V, Elem, Repr](p1: Parser[T, Elem, Repr], func: T => Parser[V, Elem, Repr])
+  case class FlatMapped[T, V, Elem, Repr](p1: Parser[Elem, Repr, T], func: T => Parser[Elem, Repr, V])
                                          (implicit repr: ReprOps[Elem, Repr])
-    extends Parser[V, Elem, Repr] {
+    extends Parser[Elem, Repr, V] {
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
       p1.parseRec(cfg, index) match{
         case f: Mutable.Failure[Elem, Repr] => failMore(f, index, cfg.logDepth, cut = false)
-        case s: Mutable.Success[T, Elem, Repr] =>
+        case s: Mutable.Success[Elem, Repr, T] =>
           val sCut = s.cut
           val res = func(s.value).parseRec(cfg, s.index)
           res.cut = sCut
@@ -40,13 +40,13 @@ object Transformers {
     override def toString = p1.toString
   }
 
-  case class Filtered[T, Elem, Repr](p: Parser[T, Elem, Repr], predicate: T => Boolean)
+  case class Filtered[T, Elem, Repr](p: Parser[Elem, Repr, T], predicate: T => Boolean)
                                     (implicit repr: ReprOps[Elem, Repr])
-    extends Parser[T, Elem, Repr] {
+    extends Parser[Elem, Repr, T] {
     override def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
       p.parseRec(cfg, index) match{
         case f: Mutable.Failure[Elem, Repr] => failMore(f, index, cfg.logDepth, cut = false)
-        case s: Mutable.Success[T, Elem, Repr] =>
+        case s: Mutable.Success[Elem, Repr, T] =>
           if (predicate(s.value)) s
           else fail(cfg.failure, index, s.traceParsers, cut = s.cut)
       }

--- a/fastparse/shared/src/main/scala/fastparse/parsers/Transformers.scala
+++ b/fastparse/shared/src/main/scala/fastparse/parsers/Transformers.scala
@@ -12,7 +12,7 @@ object Transformers {
   /**
    * Applies a transformation [[f]] to the result of [[p]]
    */
-  case class Mapper[T, V, Elem, Repr](p: Parser[Elem, Repr, T], f: T => V)
+  case class Mapper[Elem, Repr, T, V](p: Parser[Elem, Repr, T], f: T => V)
                                      (implicit repr: ReprOps[Elem, Repr])
     extends Parser[Elem, Repr, V]{
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
@@ -24,7 +24,7 @@ object Transformers {
     override def toString = p.toString
   }
 
-  case class FlatMapped[T, V, Elem, Repr](p1: Parser[Elem, Repr, T], func: T => Parser[Elem, Repr, V])
+  case class FlatMapped[Elem, Repr, T, V](p1: Parser[Elem, Repr, T], func: T => Parser[Elem, Repr, V])
                                          (implicit repr: ReprOps[Elem, Repr])
     extends Parser[Elem, Repr, V] {
     def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {
@@ -40,7 +40,7 @@ object Transformers {
     override def toString = p1.toString
   }
 
-  case class Filtered[T, Elem, Repr](p: Parser[Elem, Repr, T], predicate: T => Boolean)
+  case class Filtered[Elem, Repr, T](p: Parser[Elem, Repr, T], predicate: T => Boolean)
                                     (implicit repr: ReprOps[Elem, Repr])
     extends Parser[Elem, Repr, T] {
     override def parseRec(cfg: ParseCtx[Elem, Repr], index: Int) = {

--- a/fastparseByte/shared/src/main/scala/fastparse/byte/ByteApi.scala
+++ b/fastparseByte/shared/src/main/scala/fastparse/byte/ByteApi.scala
@@ -108,8 +108,8 @@ class ByteApi() extends Api[Byte, ByteVector](
 
 object all extends ByteApi {
   implicit def parserApi[T, V](p: T)
-                              (implicit c: T => core.Parser[V, Byte, Bytes]): ParserApi[V, Byte, Bytes] =
-    new fastparse.core.ParserApiImpl[V, Byte, Bytes](p)
+                              (implicit c: T => core.Parser[Byte, Bytes, V]): ParserApi[Byte, Bytes, V] =
+    new fastparse.core.ParserApiImpl[Byte, Bytes, V](p)
 
   /**
     * Parses the `sizeParser` to get a number `n`, and then parses `p` exactly

--- a/fastparseByte/shared/src/main/scala/fastparse/byte/ByteUtils.scala
+++ b/fastparseByte/shared/src/main/scala/fastparse/byte/ByteUtils.scala
@@ -85,7 +85,7 @@ object ByteUtils{
 
     output.toString
   }
-  private[this] type Parser[+T] = fastparse.core.Parser[T, Byte, ByteVector]
+  private[this] type Parser[+T] = fastparse.core.Parser[Byte, ByteVector, T]
 
 
   class GenericIntegerParser[T](n: Int, creator: (IsReachable[Byte], Int) => T)

--- a/perftests/shared/src/main/scala/perftests/Utils.scala
+++ b/perftests/shared/src/main/scala/perftests/Utils.scala
@@ -33,7 +33,7 @@ object Utils {
     })
   }
 
-  def benchmarkIteratorBufferSizes[Elem, Repr](parser: Parser[_, Elem, Repr],
+  def benchmarkIteratorBufferSizes[Elem, Repr](parser: Parser[Elem, Repr, _],
                                                    sizes: Seq[Int],
                                                    iteratorFactory: Int => Iterator[Repr])
                                                   (implicit repr: ReprOps[Elem, Repr],
@@ -85,7 +85,7 @@ object Utils {
   }
 
   def benchmarkAll[Elem, Repr](name: String,
-                                   parser: Parser[_, Elem, Repr],
+                                   parser: Parser[Elem, Repr, _],
                                    data: Repr, dataFailOpt: Option[Repr],
                                    iteratorFactory: Int => Iterator[Repr])
                                   (implicit repr: ReprOps[Elem, Repr],

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -19,3 +19,5 @@ addSbtPlugin("org.scala-native" % "sbt-scalajs-crossproject" % "0.2.2")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
+
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")


### PR DESCRIPTION
… to work better with -Ypartial-unification.

This fixes #176. I don't intend this to be merged in its current form as there are a bunch of other type constructors whose parameter order should also be changed, i. e. all subtypes of Parser, `Parsed` and its subtypes and more. But before I make those changes I'd like to find out if there is any support for the idea, hence the PR. 