### PR TITLE
Add Automatic-Module-Name for Java 9 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,11 @@ val shared = Seq(
           <name>Li Haoyi</name>
           <url>https://github.com/lihaoyi</url>
         </developer>
-      </developers>
+      </developers>,
+  // Java 9 settings
+  packageOptions in (Compile, packageBin) += Package.ManifestAttributes(
+    "Automatic-Module-Name" -> s"com.lihaoyi.${name.value.replace('-', '.')}"
+  )
 )
 
 lazy val nativeSettings = Seq(


### PR DESCRIPTION
This adds an [`Automatic-Module-Name`](http://branchandbound.net/blog/java/2017/12/automatic-module-name/) to the JAR manifests, allowing the library to be used on the Java 9 module path.

If the library was used before on the Java 9 module path, the module name was derived from the filename of the JAR at runtime to `sourcecode.2.12`, `sourcecode.utils.2.12`, etc., which are not a valid Java identifiers.

Fastparse is compatible with Java 9 when the dependency on sourcecode was updated to a version where https://github.com/lihaoyi/sourcecode/pull/49 is included.

Closes #184 