### PR TITLE
Seq sequence support

### DIFF
--- a/fastparse/shared/src/main/scala/fastparse/Api.scala
+++ b/fastparse/shared/src/main/scala/fastparse/Api.scala
@@ -1,8 +1,12 @@
 package fastparse
 import acyclic.file
+import fastparse.core.Implicits.Repeater
+import fastparse.core.Parser
+import fastparse.parsers.Combinators.SeqSequence
 
 import language.experimental.macros
 import fastparse.parsers.Intrinsics
+import fastparse.parsers.Terminals.Pass
 import fastparse.utils.{ElemSetHelper, ReprOps}
 
 import scala.reflect.ClassTag
@@ -90,6 +94,10 @@ abstract class Api[Elem, Repr](ct: ClassTag[Elem],
 
   def P[T](p: => Parser[T])(implicit name: sourcecode.Name): Parser[T] =
     parsers.Combinators.Rule(name.value, () => p)
+
+  def sequence[R, V](parsers: Seq[Parser[V]], sep: Parser[_] = Pass)(implicit ev: Repeater[V, R]): Parser[R] = {
+    SeqSequence[V, R, Elem, Repr](ps = parsers, delimiter = sep)
+  }
 
   type P0 = Parser[Unit]
   type Parser[+T] = core.Parser[T, Elem, Repr]

--- a/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
+++ b/fastparse/shared/src/test/scala/fastparse/ExampleTests.scala
@@ -57,6 +57,19 @@ object ExampleTests extends TestSuite{
         val Parsed.Failure(_, 7, _) = ab4c.parse("ababababac")
       }
 
+      'seqenceSeq - {
+        val a = P("a")
+        val b = P("b")
+        val ababa = Seq(a, b, a, b, a)
+        val Parsed.Success(_, 5) = sequence(ababa).parse("ababa")
+        val Parsed.Failure(_, 2, _) = sequence(ababa).parse("abba")
+        val Parsed.Success(_, 13) = sequence(ababa, sep = P(", ")).parse("a, b, a, b, a")
+        val Parsed.Failure(_, 1, _) = sequence(ababa, sep = P(", ")).parse("ababa")
+        val Parsed.Success(_, 5) = (sequence(ababa) | P("abba")).parse("ababa")
+        val Parsed.Success(_, 4) = (sequence(ababa) | P("abba")).parse("abba")
+        val Parsed.Failure(_, 2, _) = (sequence(ababa, sep = Pass ~/ Pass) | P("abba")).parse("abba")
+      }
+
       'option - {
         val option = P( "c".? ~ "a".rep(sep="b").! ~ End)
 


### PR DESCRIPTION
Adds support for `sequence`. It allows multiple parsers (with same result type) to be combined with possibly a(n ignored) separator parser, just like in `rep`.

Feel free to suggest changes.