### PR TITLE
Fix Scaladoc of `~~` operator

### DIFF
--- a/fastparse/src/fastparse/package.scala
+++ b/fastparse/src/fastparse/package.scala
@@ -154,8 +154,8 @@ package object fastparse {
 
     /**
       * Raw sequence operator. Runs two parsers one after the other,
-      * with optional whitespace in between. If both parsers
-      * return a value, this returns a tuple.
+      * *without* whitespace in between. If both parsers return a value,
+      * this returns a tuple.
       */
     def ~~[V, R](other: P[V])
                 (implicit s: Implicits.Sequencer[T, V, R],


### PR DESCRIPTION
This PR fixes the Scaladoc of the `~~` operator under `EagerOps`, since it runs two parsers without whitespace in between.