### PR TITLE
Add Documentation for Higher Order Parsers

### DIFF
--- a/fastparse/test/src/fastparse/ExampleTests.scala
+++ b/fastparse/test/src/fastparse/ExampleTests.scala
@@ -516,7 +516,7 @@ object ExampleTests extends TestSuite{
       def Indexed[_: P, T](p: => P[T]): P[(Int, T, Int)] = P( Index ~ p ~ Index )
 
       def Add[_: P] = P( Num ~ "+" ~ Num )
-      def Num[_: P] = I( CharsIn("0-9").rep.! )
+      def Num[_: P] = Indexed( CharsWhileIn("0-9").rep.! )
 
       val value = parse("1+2", Add(_))
 

--- a/fastparse/test/src/fastparse/ExampleTests.scala
+++ b/fastparse/test/src/fastparse/ExampleTests.scala
@@ -512,6 +512,17 @@ object ExampleTests extends TestSuite{
       }
     }
 
+    'higherorder{
+      def Indexed[_: P, T](p: => P[T]): P[(Int, T, Int)] = P( Index ~ p ~ Index )
+
+      def Add[_: P] = P( Num ~ "+" ~ Num )
+      def Num[_: P] = I( CharsIn("0-9").rep.! )
+
+      val value = parse("1+2", Add(_))
+
+      assert(value == (0, "1", 1, 2, "2", 3))
+    }
+
     'folding{
       sealed trait AndOr
       case object And extends AndOr

--- a/fastparse/test/src/fastparse/ExampleTests.scala
+++ b/fastparse/test/src/fastparse/ExampleTests.scala
@@ -518,9 +518,7 @@ object ExampleTests extends TestSuite{
       def Add[_: P] = P( Num ~ "+" ~ Num )
       def Num[_: P] = Indexed( CharsWhileIn("0-9").rep.! )
 
-      val value = parse("1+2", Add(_))
-
-      assert(value == (0, "1", 1, 2, "2", 3))
+      val Parsed.Success((0, "1", 1, (2, "2", 3)), _) = parse("1+2", Add(_))
     }
 
     'folding{

--- a/readme/WritingParsers.scalatex
+++ b/readme/WritingParsers.scalatex
@@ -418,3 +418,19 @@
                 To explicitly isolate a cut to one branch of a parser, place that branch within @hl.scala{NoCut}.  Cuts within that branch will prevent backtracking inside that branch, but if that branch fails alternate branches will be tried as normal.
 
             @hl.ref(tests/"ExampleTests.scala", Seq("'composenocut", ""))
+
+    @sect{Higher Order Parsers}
+
+        @p
+            It is possible to write functions that take parsers as arguments and return other parsers. These are useful because it allows for the programmatic modification of many different parsers. This can be used to generate a large amount of parsers that only vary in minor ways.
+
+        @p
+            Parser arguments @b{must be passed by name}! Parsers are immediately evaluated, so if they aren't passed by name they will be evaluated when they are passed into a function, not within it, causing either a warning about @hl.scala{a pure expression does nothing in statement position} at compile time or a @hl.scala{ClassCastException} at runtime.
+
+        @p
+            A simple example of a higher order parser is one that adds index information to the beginning and end of the parse.
+
+        @hl.ref(tests/"ExampleTests.scala", Seq("'higherorder", ""))
+
+        @p
+            While this is a simple example, this concept to be extended to your hearts content.


### PR DESCRIPTION
Examples and docs should compile according to travis. I don't currently have Mill set up to test locally, but as far as I can tell things are working well.