### PR TITLE
Split release stage into parallel jobs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,17 @@ jobs:
   - stage: release
     script:
       - echo "$PGP_SECRET" | base64 --decode | gpg --import
-      - mill __.publish --sonatypeCreds "$SONATYPE_USERNAME:$SONATYPE_PASSWORD" --release true --gpgPassphrase "$PGP_PASSPHRASE"
+      - mill __[2.12.7].publish --sonatypeCreds "$SONATYPE_USERNAME:$SONATYPE_PASSWORD" --release true --gpgPassphrase "$PGP_PASSPHRASE"
+
+  - stage: release
+    script:
+      - echo "$PGP_SECRET" | base64 --decode | gpg --import
+      - mill __[2.11.12].publish --sonatypeCreds "$SONATYPE_USERNAME:$SONATYPE_PASSWORD" --release true --gpgPassphrase "$PGP_PASSPHRASE"
+
+  - stage: release
+    script:
+      - echo "$PGP_SECRET" | base64 --decode | gpg --import
+      - mill __[2.13.0-RC1].publish --sonatypeCreds "$SONATYPE_USERNAME:$SONATYPE_PASSWORD" --release true --gpgPassphrase "$PGP_PASSPHRASE"
 
 before_install:
 - curl -L -o ~/bin/mill https://github.com/lihaoyi/mill/releases/download/0.3.6/0.3.6-85-38fce6 && chmod +x ~/bin/mill


### PR DESCRIPTION
The stable release for 2.1.1 timed out on Travis due to the maximum 50
minute limit. This commit splits the release stage into three parallel
jobs to publish 2.11, 2.12 and 2.13 separately. This will hopefully
overcome the timeout limit on Travis CI.

Review @alexarchambault 