### PR TITLE
improve examples for `Positive Lookahead`

### DIFF
--- a/fastparse/test/src/fastparse/ExampleTests.scala
+++ b/fastparse/test/src/fastparse/ExampleTests.scala
@@ -171,7 +171,8 @@ object ExampleTests extends TestSuite{
         def keyword[_: P] = P( ("hello" ~ &(" ")).!.rep )
 
         val Parsed.Success(Seq("hello"), _) = parse("hello ", keyword(_))
-        val Parsed.Success(Seq(), __) = parse("helloX", keyword(_))
+        val Parsed.Success(Seq(), _) = parse("hello", keyword(_))        
+        val Parsed.Success(Seq(), _) = parse("helloX", keyword(_))
       }
 
       test("neglookahead"){

--- a/fastparse/test/src/fastparse/ExampleTests.scala
+++ b/fastparse/test/src/fastparse/ExampleTests.scala
@@ -93,7 +93,7 @@ object ExampleTests extends TestSuite{
         def option[_: P] = P( "c".? ~ "a".rep(sep="b").! ~ End)
 
         val Parsed.Success("aba", 3) = parse("aba", option(_))
-        val Parsed.Success("aba", 3) = parse("aba", option(_))
+        val Parsed.Success("aba", 4) = parse("caba", option(_))
       }
 
       test("either"){


### PR DESCRIPTION
- change a use of `__` to `_`
- add one more example