### PR TITLE
Fix docJar for Scala Native 0.3.9

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -3,6 +3,8 @@ import scalalib._
 import scalajslib._
 import scalanativelib._
 import publish._
+import mill.eval.Result
+import mill.modules.Jvm.createJar
 
 val crossVersions = Seq("2.12.10", "2.13.1")
 val crossJsVersions = Seq(
@@ -48,6 +50,11 @@ object fastparse extends Module{
     def platformSegment = "native"
     def millSourcePath = super.millSourcePath / ammonite.ops.up
     def scalaNativeVersion = crossScalaNativeVersion
+    override def docJar = T {
+      val outDir = T.dest
+      os.makeDir.all(outDir / 'javadoc)
+      createJar(Agg(outDir / 'javadoc))(outDir)
+    }
     object test extends Tests with CommonTestModule{
       def platformSegment = "native"
     }


### PR DESCRIPTION
Sadly I couldn't find a way to avoid generating a proper docJar for Scala Native `0.4.0-M2` (since it works correctly) because code like this:
```scala
if(scalaNativeVersion == "0.3.9") {
  val outDir = T.dest
  os.makeDir.all(outDir / 'javadoc)
  createJar(Agg(outDir / 'javadoc))(outDir)
} else super.docJar()
```
tries to run `super.docJar()` regardless of the result of the if expression.
If you have a solution to this problem I can change that.
Otherwise we can live with an empty docJar for Scala Native 😃