### PR TITLE
Use Scala3's union type for stronger typing on `|`

### DIFF
--- a/fastparse/src-3/fastparse/internal/MacroInlineImpls.scala
+++ b/fastparse/src-3/fastparse/internal/MacroInlineImpls.scala
@@ -287,8 +287,8 @@ object MacroInlineImpls {
     }
   }
 
-  inline def eitherInline[T, V >: T](inline lhs0: ParsingRun[T])(inline other: ParsingRun[V])(ctx5: ParsingRun[Any])
-      : ParsingRun[V] = {
+  inline def eitherInline[T, V](inline lhs0: ParsingRun[T])(inline other: ParsingRun[V])(ctx5: ParsingRun[Any])
+      : ParsingRun[V | T] = {
 
     val oldCut = ctx5.cut
     ctx5.cut = false
@@ -299,8 +299,8 @@ object MacroInlineImpls {
     val lhsAggregate = ctx5.aggregateMsgs
     if (ctx5.isSuccess) {
       ctx5.cut |= oldCut
-      ctx5.asInstanceOf[ParsingRun[V]]
-    } else if (ctx5.cut) ctx5.asInstanceOf[ParsingRun[V]]
+      ctx5.asInstanceOf[ParsingRun[V | T]]
+    } else if (ctx5.cut) ctx5.asInstanceOf[ParsingRun[V | T]]
     else {
       val verboseFailures = ctx5.verboseFailures
 
@@ -317,7 +317,7 @@ object MacroInlineImpls {
       if (verboseFailures) {
         ctx5.reportAggregateMsg(rhsMsg ::: lhsMsg, ctx5.aggregateMsgs  ::: lhsAggregate)
       }
-      ctx5.asInstanceOf[ParsingRun[V]]
+      ctx5.asInstanceOf[ParsingRun[V | T]]
     }
   }
 

--- a/fastparse/src-3/fastparse/package.scala
+++ b/fastparse/src-3/fastparse/package.scala
@@ -42,7 +42,7 @@ package object fastparse extends fastparse.SharedPackageDefs {
       * fails it backtracks and tries to pass the right-hand-side. Can be
       * chained more than once to parse larger numbers of alternatives.
       */
-    inline def |[V >: T](inline other: P[V])(using ctx: P[Any]): P[V] =
+    inline def |[V](inline other: P[V])(using ctx: P[Any]): P[V | T] =
       MacroInlineImpls.eitherInline[T, V](parse0)(other)(ctx)
 
     /** Plain cut operator. Runs the parser, and if it succeeds, backtracking


### PR DESCRIPTION
Hello, just a tiny signature-change that would improve our quality of life using fastparse in Scala3 :slightly_smiling_face:

Scala3 now has union types, which are perfect to express the type of the either-or parser combinator `|` but is unused in fastparse.

In our code, this leads to cases like:

```scala
class A <: Base
class B <: Base

def f(x: A | B): Something

def parseA: P[A]
def parseB: P[B]

def fancyParse: P[Something] = (parseA | parseB).map(
(x: Base) => f(x.asInstanceOf[A|B])
)
```
The asInstanceOf is required to bridge `(parseA | parseB)`, currently typed to some common supertype, here `P[Base]`, where it could now simply be typed `P[A|B]`, which this PR offers :slightly_smiling_face: I just wanted to clarify the motivation, in case I missed an existing alternative or what not!

It sounds as non-intrusive as can be to me, not sure if I'm missing something though; similarly, I saw type tests specifically for implicit sequencers and everything, but none for the type of combined parsers. Tell me if you feel like this requires specific tests here!